### PR TITLE
Add treasury withdrawal proposals

### DIFF
--- a/proposals/137/treasury_withdrawal.md
+++ b/proposals/137/treasury_withdrawal.md
@@ -5,16 +5,23 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: OpShin - Python Smart Contracts for Cardano
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 199,911 ADA (199910890000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** This is OpShin: a toolchain that lets developers construct Cardano smart contracts in Python.  The toolchain comprises several projects that aim to facilitate the development of Smart Contracts and dApps on Cardano. They are largely based on Python, or integrate well with it for maximal accessibility. On top of accessibility, OpShin ensures low transaction cost compared to PlutusTx.
+
+At the time of writing, Python is the second-most used language on GitHub, with 14.75% of the active userbase working with Python, and enjoys a 22.5% year-over-year increase in users; this is driven in part by its utility in data science and machine learning.
+
+Everyone who knows Python can leverage the toolstack available for Python development to build on Cardano; and that is a lot of people, with a lot of tools.
+
+
+OpShin enforces strict typing on the high-level programming: it implements a type system on top of Python type hints. However, all traces of typing are erased during compilation, for a maximum efficiency program. OpShin beats many programming languages when taken to the test for real use-cases.
+- **Audit & Oversight Allocation:** 9995 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +57,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/152/treasury_withdrawal.md
+++ b/proposals/152/treasury_withdrawal.md
@@ -5,16 +5,23 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: OSC Budget Proposal - Paid Open Source Model for Sustainable Development
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 5,885,000 ADA (5885000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** The Open Source Committee in conjunction with the Open Source Office (OSO) seeks to enact a Paid Open Source Model for Sustainable Development in Cardano. A budget proposal of ₳5,885,000 (approx. $2.94M USD), designed to ensure the long-term sustainability of open-source development within the Cardano ecosystem. This initiative will be managed by the Open Source Committee (OSC) pending approval by the DReps, and seeks to address the critical funding gaps that hinder the maintenance, security, and growth of essential open-source projects.
+
+*Key Objectives & Strategic Impact*
+- Sustainable Open-Source Development: Funding for 50+ key projects via the Maintainer Retainer Program ensures continuous innovation and maintenance of mission-critical repositories.
+- Developer Onboarding & Retention: Programs like Cardano Summer of Code, Code For Us, and Developer Advocates provide clear pathways for new and experienced contributors to engage in Cardano development.
+- Security & Infrastructure Reliability: Investments in Bug Bounties, Incident Monitoring, and Tooling Sustainability safeguard the network and strengthen ecosystem resilience.
+- Commercialization & Ecosystem Growth: The Accelerator Research Program and Expanded Project Support Services transition promising projects from incubation to sustainable businesses.
+- Community Engagement & Governance: The OSC ensures transparent fund allocation, performance monitoring, and open participation for contributors across Cardano.
+- **Audit & Oversight Allocation:** 294250 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +57,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/157/treasury_withdrawal.md
+++ b/proposals/157/treasury_withdrawal.md
@@ -5,16 +5,18 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Cardano Ecosystem Pavilions at Exhibitions
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 1,119,333 ADA (1119333000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** We propose to host Ecosystem Pavilions at numerous Exhibitions around the world. The funding will ensure that projects are able to have access to much more affordable prices to have a presence at the event. Non of the spots or travel budgets will be 100% funded. We will also be ensuring that projects that sign up understand the importance of pre event work, during the event work and follow up work to achieve the best possible ROI. The aim is that it will give projects a more affordable entry and education into how to truly make the most of exhibitions and marketing. 
+
+Please visit out website for a more thorough breakdown and explanation:
+- **Audit & Oversight Allocation:** 55966 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +52,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/174/treasury_withdrawal.md
+++ b/proposals/174/treasury_withdrawal.md
@@ -5,16 +5,20 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: AdaStat.net Cardano blockchain explorer
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 212,000 ADA (212000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** We propose to continue development and support of the AdaStat.net Cardano blockchain explorer for the next 24 months. Planned work includes performance optimizations, improvements to UX/UI, and new features related to Cardano’s evolving governance model and on-chain tooling.
+
+The frontend is developed using Vue.js and Tailwind CSS, which allows very small bundle size and fast loading time on different devices. The backend is built on Node.js and PostgreSQL, combining standard DB-Sync tables with custom-optimized indexes for high-speed data access. This dual approach enables advanced search and filtering across both on-chain and off-chain metadata — including DRep names, stake pool tickers, token labels, and more.
+
+Infrastructure is horizontally scalable. Multiple backend servers work behind load balancer and handle traffic based on real-time utilization. This gives high availability and stable performance, even during peak usage.
+- **Audit & Oversight Allocation:** 10600 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +54,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/205/treasury_withdrawal.md
+++ b/proposals/205/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: TWEAG’s  Proposals for multiple core budget projects for Cardano  2025
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 11,070,323 ADA (11070322680000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Explained in the attached document
+- **Audit & Oversight Allocation:** 553516 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/232/treasury_withdrawal.md
+++ b/proposals/232/treasury_withdrawal.md
@@ -1,0 +1,109 @@
+<!--
+Template for Cardano Treasury Withdrawal Proposals
+
+This template combines the constitutional requirements for Treasury Withdrawals
+and the terms established in the approved Budget Info Action.  Replace each
+placeholder ({{...}}) with the appropriate value for each proposal.
+-->
+# Treasury Withdrawal Proposal: Catalyst 2025 Proposal by Input Output: Advancing Decentralised Community Innovation Funding & Infrastructure
+
+## Withdrawal Details
+- **Amount:** 69,459,000 ADA (69459000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Project Catalyst has emerged as a cornerstone of decentralized innovation and funding within the Cardano ecosystem. As a pioneering governance mechanism, Catalyst has enabled over three million on-chain decisions and the allocation of over ₳290 million to more than 2,000 projects in 114 countries. However, with growth comes complexity. As community participation, funding demand, and governance sophistication increase, so too does the need to address critical structural and operational challenges. This proposal lays out a coordinated plan to provide reliable ecosystem funding and to future-proof Catalyst through a set of transformative upgrades that supports the Cardano 2025 Roadmap and community-validated priorities across three core workstreams:
+
+1.  **Catalyst Interface Design and Development for Diversified Funding Streams**
+    * **Objective:** Reduce operating costs by up to 50% and increase both voting power and wallet participation by 30-50% minimum by improving accessibility across all devices and completing the unification of all the remaining components of the Catalyst user experience: combining ideation, proposal submission, community contributor roles (reviewing, moderating), voting, and project administration. For Catalyst, this means further design, development, and automation of user journeys and work flows for each type of Catalyst user experience.
+    * **Outcome:** Unlock the full end-to-end Catalyst experience for community members using any device to reduce barriers to entry and boost adoption (especially in emerging markets with high rates of smartphone ownership vs desktop).
+    * **Output:** This will deliver unified Catalyst interfaces covering complex Fund Operations and funding administration components. Leveraging existing UX design system for Catalyst App and Flutter for its cross-platform portability to move from desktop to device-agnostic optimization:
+        * User-centric admin interfaces and dashboards. All proposals, reviewer data, evidence of milestone achievements, and impact reporting data is transparently and intuitively available so community members can track the development and progress of project proposals and teams they interact with.
+        * User contribution and participation is tracked for reputation-score and incentives attributions
+        * Diversified funding and decision-making beyond ADA with Cardano Native Tokens. Administration interfaces allow token issuers and co-funders to create additional funding opportunities such as match-funding and donations. CNT back-end development is already complete meaning Catalyst can index Cardano blockchain to take voting power attribution from any Cardano Native Token. Only interface design unleashes all this potential.
+        * Streamlined milestone management: Proposal data seamlessly transfers into the statement of milestones via deep hooks to milestone module
+        * Funding and contribution dashboards give users clear communications, receipts, and reputation surfaces
+        * Automated assignments and forfeitures ensure reviewers are complying, timely, and accountable to service level agreements
+        * Integrated impact data reporting and evaluation using standardized impact measurements
+        * Design foundations for the integration of funding and resolution smart contracts
+    * **Features:**
+        * Discover, Subscribe, and Interact w/ Funders and Projects: allow users to find and participate in many programs
+        * Advanced user preferences
+        * Research: Assisted search, AI, regionality, language, insights
+        * Legacy Integrations & Deployments: upgrade legacy tools and integrations to deep hook into concurrent programs
+        * Mobile Wallet Connect Research: understand existing solutions and challenges to enable mobile wallet connections
+        * Advanced Design Research: test and validate approaches to translating desktop UX to mobile and deep hooks
+        * Cardano Native Token Support: index Cardano holdings and make them available to Catalyst tools and interfaces
+        * Self-Service Campaign Portal: Provide scalable tools for campaign configuration, deployment, and management
+        * Device agnostic development: address other platform-specific requirements to ensure seamless mobile platform integration.
+        * Deployment Pipeline: enable seamless CI/CD app deployment, without reliance on other teams
+        * Account Restoration: allow a user to easily restore an existing account to a new device
+
+2.  **Production-Grade Decentralised Catalyst Infrastructure via Hermes**
+    * **Objective:** Advance the decentralisation, scalability, and auditability of Project Catalyst by delivering a rigorously stress tested implementation of Hermes to replace federated infrastructure with a fully distributed, peer-to-peer system. This includes enabling parallel voting events, secure Cardano-based vote casting, and public auditability of historic voting data that eliminates reliance on Web2 infrastructure services, empowering open innovation and ecosystem governance.
+    * **Outcome:** maturing the state of the art of the Project Catalyst technology stack beyond the existing proof of concept and delivering production-ready Catalyst infrastructure using a fully distributed database and immutable ledger, configurable administration interfaces, eliminating reliance on a federated side-chain and small number of nodes while maintaining many artefacts are published to Cardano mainchain.
+    * **Output:** Enhanced scalability and flexibility of Catalyst governance: multiple funding rounds using multiple tokens can run concurrently or overlap, dramatically increasing the system's utility and responsiveness. Stronger security and voter confidence through direct blockchain-based verification and vote casting, reducing trust assumptions. Full decentralisation of Catalyst infrastructure : no dependency on federated servers or Web2 storage, reducing censorship risks and increasing resilience. Greater transparency and auditability : historic voting data is verifiable, immutable, and accessible through distributed networks Developer empowerment : Builders can deploy secure, complex, and custom applications like governance mechanisms on Hermes with minimal barriers via IPFS and WebAssembly.
+    * **Features:**
+        * Upgrade WASM Engine to latest Wasm Component Model required for Hermes Application Logic.
+        * Enhance WASM module Linker to support partial linking for modules which do not contain all events, or use all functions provided by the Hermes runtime.
+        * Add events for WASM driven validation of data published over IPFS Pub/Sub or the DHT.
+        * Make Hermes engine execute multiple WASM modules in parallel for performance and scalability testing
+        * Implement a generalised solution to uniformly manage system resources.
+        * Hermes package can read data directly from IPFS, not from a local copy downloaded from IPFS.
+        * Enable execution of Hermes applications from an IPFS link, not only a locally present application.
+        * Implement cryptography for 2024’s applied research into Quadratic Voting and Time-Weighted Stake models
+
+3.  **F14-F16 Catalyst Funding Rounds, Retroactive Public Goods Funding (RetroPGF), Fund Operations**
+    * **Objective:** Allocate ₳61M across three consecutive funding rounds (Fund 14, 15, and 16) during a 12 month period from when the funds are first disbursed.
+    * **Outcome:** This substantial investment aims to yield tangible results of 500-700 new Cardano projects. Dates provided below are for illustrative purposes only.
+    * **Outputs:**
+        * Fund14 Target launch May , initial disbursements of funds in July/August 2025
+        * Fund15 Target launch in August , initial disbursement of funds in Dec 2025/ Jan 2026
+        * Fund16 Target launch in October , initial disbursement of funds in Feb-Mar 2026
+        * 30-40% of allocated funds (₳24-₳30M) are projected to result in real-world adoption or industrial use-case partnerships.
+        * ₳60m in funding will be strategically distributed across four key areas: early-stage R&D, later-stage product development, grassroots ecosystem initiatives, and open-source software development:
+            * Cardano Concepts: supporting early stage use-case application development and demonstration from proof of concept (POC) to minimum viable product (MVP)
+            * Cardano Partners & Products: supporting later stage market-ready products and use-case implementation for single applicants or in collaboration with industry leading partners to deliver real world pilot-trials
+            * Cardano Open Developers: Focused on supporting Cardano’s open source developer ecosystem efforts. Intended for the scope of this category to be set in consultation with the Open Source Committee.
+            * Cardano Open Ecosystem: Focused on non-technical proposals for grassroots Cardano regional growth and community-building projects. Intended for the scope of this category to be set in consultation with the Membership and Community Committee and relevant working group participants
+        * ₳1m allocated for Retroactive Public Goods Funding (RetroPGF) program
+
+**Total Requested Budget for three workstreams:** ₳69,459,000 (or $34,729,500)
+- **Audit & Oversight Allocation:** 3472950 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
+- **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
+
+## References
+- Constitution Hash: 8c653ee5c9800e6d31e79b5a7f7d4400c81d44717ad4db633dc18d4c07e4a4fd00
+- Approved Net Change Limit Hash: 9b62b3c632f329016a968ac25211825bb4f84b12461121c7da3aa11df92370f900
+- Approved Budget Hash: e14de8d9dc4f4ddf3fe9250a8a926e20f10e99b86bd0610b77d7a054981591ee00
+
+## Budget Reference
+> On behalf of Intersect and the Cardano Budget Committee, this Budget Info Action proposes a Cardano Blockchain Ecosystem Budget of 275,269,340 ada. The period during which this Budget Info Action remains in effect will begin at the close of its voting period and continue for 73 epochs (52 weeks). This budget is an aggregate allocation and following Treasury Withdrawal(s) must be in compliance with an approved and active Net Change Limit, among other conditions. This budget comprises 39 proposals that support maintenance, development, marketing, innovation, and governance initiatives within the Cardano Blockchain Ecosystem.
+
+## Net Change Limit Clause
+> The total requested funding sits below the Net Change Limit (NCL) currently in force, 350 trillion lovelace, or 350 million ada, as of 8 May 2025. Consequently, each subsequent Treasury Withdrawal must be presented and approved only if it remains within the then-active NCL, in line with Article IV of the Cardano Constitution and Guardrail: TREASURY-02a.
+
+## Constitutional Requirements
+
+### Article IV, Section 3
+> Withdrawals from the Cardano Blockchain treasury that would cause the Cardano Blockchain treasury balance to violate the then applicable net change limit shall not be permitted.
+> No withdrawals from the Cardano Blockchain treasury shall be permitted unless such withdrawals have been authorized and are being made pursuant to a budget for the Cardano Blockchain that is then in effect as required by the Cardano Blockchain Guardrails Appendix, and which has not been determined by the Constitutional Committee to be unconstitutional.
+
+### Article IV, Section 4
+> Any governance action requesting ada from the Cardano Blockchain treasury shall require an allocation of ada as a part of such funding request to cover the cost of periodic independent audits and the implementation of oversight metrics as to the use of such ada.
+> Contractual obligations governing the use of ada received from the Cardano Blockchain treasury pursuant to a Cardano Blockchain ecosystem budget shall include dispute resolution provisions.
+
+### Article IV, Section 5
+> Any ada received from a Cardano Blockchain treasury withdrawal, so long as such ada is being held directly or indirectly by an administrator prior to further disbursement, must be kept in one or more separate accounts that can be audited by the Cardano Community, and such accounts shall not be delegated to an SPO but must be delegated to the predefined auto abstain voting option.
+
+### Guardrails on Treasury Withdrawal Actions
+> TREASURY-01a (x) A net change limit for the Cardano treasury's balance per period of time **must** be agreed by the DReps via an on-chain governance action with a threshold of greater than 50% of the active voting stake.
+> TREASURY-02a (x) Withdrawals from the Cardano Blockchain treasury made pursuant to an approved Cardano Blockchain ecosystem budget **must not** exceed the net change limit for the Cardano Treasury's balance per period of time.
+> TREASURY-03a (x) Withdrawals from the Cardano Blockchain treasury **must** be denominated in ada.
+> TREASURY-04a (x) Withdrawals from the Cardano Blockchain treasury **must not** be ratified until there is a Cardano Community approved Cardano Blockchain ecosystem budget then in effect pursuant to a previous on-chain governance action agreed by the DReps with a threshold of greater than 50% of the active voting stake.
+
+## Fund Management & Oversight
+- Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
+- Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/299/treasury_withdrawal.md
+++ b/proposals/299/treasury_withdrawal.md
@@ -5,16 +5,37 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: 2025 Input Output Engineering Core Development Proposal
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 96,817,080 ADA (96817080000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Thank you for your review and consideration. Please see the full proposal in the attached for additional information.
+
+* **Automatic Formal Verification (Plutus High Assurance):** Develop automated formal verification tool for Plinth/Cardano DApps. (**$1,859,000**)
+* **Property Based Testing Tool (Plutus High Assurance):** Develop Plinth PBT Tool to automatically generate diverse inputs/actions. (**$2,366,000**)
+* **Static Analyzer (Plutus High Assurance):** Develop "one-click" static analysis tool for Plinth contracts. (**$777,140**)
+* **Ouroboros Leios Implementation:** Begin core implementation of Leios L1 consensus protocol. (**$7,098,000**)
+* **Cardano Node Architecture Refresh (Acropolis):** Re-architect the Cardano node into a modular model (Acropolis). (**$2,028,000**)
+* **Hydra Development:** Complete Hydra v1.0 mainnet and full audit, Cardano's L2 state channel solution. (**$1,859,000**)
+* **Minotaur AVS:** Launch Minotaur, Actively Validated Service (AVS) leverage Cardano L1 security. (**$1,900,000**)
+* **Mithril Development:** Enhance Mithril protocol for secure, efficient access. Speeds up sync, enables light clients. (**$1,859,000**)
+* **KES Agent:** Implement security enhancement for SPO KES key storage and management. (**$676,000**)
+* **Ledger-HD:** Move ledger state tables from memory to disk (LSM tech) to reduce RAM. (**$1,352,000**)
+* **Log-Structured Merge (LSM) including UTXO-HD:** Integrate bespoke Well-Typed LSM-tree backend for managing on-disk state. (**$1,352,000**)
+* **Revised Stake Pool Incentive Scheme:** Investigate potential adjustments to SPO incentive scheme. (**$1,352,000**)
+* **Nested Transactions (Babel Fees):** Implement Nested Transactions ledger feature enabling tx batching. Facilitates Babel Fees. (**$1,352,000**)
+* **Plutus Core Roadmap:** Execute roadmap for Plutus Core delivering key new primitives. (**$2,704,000**)
+* **Tiered Pricing Models (Plutus High Assurance):** Introduce transaction prioritization mechanism to improve predictability during congestion. (**$1,352,000**)
+* **Transaction Monitoring System (Plutus High Assurance):** Develop system to monitor transactions, detect potential fraud/anomalies. (**$1,690,000**)
+* **Maintenance and Support:** Maintenance of existing code base, ongoing support. Includes cost of running Test & Tracing setup. (**$14,682,000**)
+* **Audit & Security Assurance:** Engage independent audits and security assurance. Consolidated item. (**$2,150,400**)
+
+**GRAND TOTAL: $48,408,540**
+- **Audit & Oversight Allocation:** 4840854 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +71,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/324/treasury_withdrawal.md
+++ b/proposals/324/treasury_withdrawal.md
@@ -5,16 +5,20 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Eternl Maintenance
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 583,000 ADA (583000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Eternl has been a reliable and community-driven Cardano wallet since its launch 2021 . It offers a secure, feature-rich experience across web, browser extension, iOS, and Android platforms, serving both everyday users and developers.
+
+Maintaining Eternl requires €30,000 per month.
+
+We seek funding from the Cardano budget to sustain these operational costs, ensuring Eternl continues to provide reliable access to the Cardano blockchain for the community.
+- **Audit & Oversight Allocation:** 29150 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +54,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/389/treasury_withdrawal.md
+++ b/proposals/389/treasury_withdrawal.md
@@ -5,16 +5,17 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Unveiling the First  Unified Global Events  Marketing Strategy  for Cardano
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 6,000,000 ADA (6000000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** To revitalize Cardano's global presence and foster ecosystem growth, we aim to host and participate in a dynamic series of events in 2025 and 2026.
+These events will target diverse audiences, including developers, enterprises, blockchain enthusiasts, and policymakers, to drive engagement, innovation, and adoption.
+- **Audit & Oversight Allocation:** 300000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +51,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/39/treasury_withdrawal.md
+++ b/proposals/39/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Dolos: Sustaining a Lightweight Cardano Data Node
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 220,914 ADA (220914000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** This request for support focuses on Dolos (https://dolos.txpipe.io/), a lightweight Cardano data node, designed as a backend for dApps. It is fine-tuned to solve a very narrow scope: keeping an updated copy of the ledger and replying to queries from trusted clients. Unlike a full Cardano node, Dolos is optimized for minimal resource usage while maintaining high data integrity and responsiveness. As an open-source project, Dolos has been steadily growing in adoption, with 366 commits, 367 pull requests, and contributions from 21 developers. It is becoming a key tool for projects seeking efficient blockchain data access without the overhead of full-node infrastructure. To ensure Dolos continues to evolve alongside Cardano’s ecosystem, we are requesting funding for the following roles: 0.5 FTE Blockchain Developer and 0.125 FTE Tech Lead.
+- **Audit & Oversight Allocation:** 11045 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/40/treasury_withdrawal.md
+++ b/proposals/40/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: UTxO RPC: Sustaining Cardano Blockchain Integration
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 220,914 ADA (220914000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** This request for support focuses on UTxO RPC (https://utxorpc.org), an interface specification designed to simplify interactions with UTxO-based blockchains. U5C defines standardized methods, data structures, and communication patterns. By providing a range of SDKs, and offering thorough documentation, U5C enhances reusability, interoperability, and performance in blockchain integrations. Currently in its early stages, UTxO RPC is already being adopted by key projects in the Cardano ecosystem, including Lace, Mesh, Amaru, and many others. As an open-source initiative, it welcomes contributions from the community, fostering a collaborative approach to improving blockchain infrastructure. To support its ongoing development, maintenance, and enhancements, we are requesting funding for the following roles: 0.5 FTE blockchain developer and 0.125 FTE tech lead.
+- **Audit & Oversight Allocation:** 11045 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/41/treasury_withdrawal.md
+++ b/proposals/41/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Pallas: Sustaining Critical Rust Tooling for Cardano
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 220,914 ADA (220914000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** This request for support focuses on Pallas (github.com/txpipe/pallas), a collection of Rust-native building blocks for the Cardano blockchain ecosystem. Pallas provides reusable components, such as cryptographic primitives and CBOR encoding, to enable the development of higher-level use cases like explorers and wallets. The project remains open-source, and actively welcomes contributions from the broader Cardano developer community. With 591 commits, over 430 pull requests, and 39 contributors, it stands as a strong example of open-source collaboration in the ecosystem. Pallas is being used by key projects in the ecosystem such as Aiken, Lucid, Mithril, Amaru, and many others. To ensure its continued evolution and maximize its impact, Pallas requires ongoing maintenance, updates, and new functionalities. We are requesting funding to secure the following roles assigned to the project: 0.5 FTE blockchain developer and 0.125 FTE tech lead.
+- **Audit & Oversight Allocation:** 11045 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/42/treasury_withdrawal.md
+++ b/proposals/42/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: MLabs Core Tool Maintenance & Enhancement: Cardano.nix
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 45,217 ADA (45217000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** This proposal seeks annual funding for the maintenance and enhancement of Cardano.nix, a foundational toolset for building and deploying Cardano infrastructure with Nix. Funding covers regular maintenance to ensure compatibility with Cardano node updates and the Nix ecosystem, bug fixes, and minor enhancements to improve the tooling based on community needs and developments in related areas like Nix Flakes.
+- **Audit & Oversight Allocation:** 2260 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/454/treasury_withdrawal.md
+++ b/proposals/454/treasury_withdrawal.md
@@ -5,16 +5,39 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: BloxBean Java Tools Maintenance and Enhancement
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 99,600 ADA (99600000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** BloxBean provides several essential Java libraries and tools for building applications on Cardano. These tools—CCL, Yaci, Yaci Store, and Yaci DevKit—require continuous maintenance and feature updates to meet the evolving needs of the Cardano ecosystem.  
+
+To meet the growing demands of this project, we require an additional full-time developer for the next 12 months.  
+
+The requested funds will support this additional developer, who will focus on the following areas:  
+
+1. Ongoing Maintenance:  
+
+     - Ensure compatibility with new Cardano network upgrades.  
+     - Address bug fixes, performance improvements, and security issues.  
+
+2. Feature Enhancements:  
+
+   - Implement new features based on community feedback.  
+   - Optimize the codebase to improve performance and scalability.  
+
+3. Documentation and Developer Tools:
+  
+    - Expand the documentation with detailed guides, tutorials, and example code to assist developers.
+
+4.  Community Engagement & Support:
+   
+      - Provide ongoing support via GitHub discussions, forums, and discord.
+      - Engage with developers to understand their needs and ensure tools are optimized for real-world use.
+- **Audit & Oversight Allocation:** 4980 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +73,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/464/treasury_withdrawal.md
+++ b/proposals/464/treasury_withdrawal.md
@@ -1,0 +1,94 @@
+<!--
+Template for Cardano Treasury Withdrawal Proposals
+
+This template combines the constitutional requirements for Treasury Withdrawals
+and the terms established in the approved Budget Info Action.  Replace each
+placeholder ({{...}}) with the appropriate value for each proposal.
+-->
+# Treasury Withdrawal Proposal: Input Output Research (IOR): Cardano Vision - Work Program 2025
+
+## Withdrawal Details
+- **Amount:** 26,848,000 ADA (26848000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** The IOR proposal for Work Program 2025 consists of 20 research streams and 6 technology validation streams from Cardano Vision, a five-year program consisting of 34 research streams across 9 thematic focus areas. Over a five-year period, this funnel approach is expected to generate over 100 high-quality research outputs and provide the foundation for 30 or more technology validation streams, to be implemented into Cardano’s Testnet and Mainnet by engineers and developers from the Cardano community.
+
+For the full Cardano Vision proposal and supporting presentation, along with Fundamental Research and Technology Validation workstream plans prioritised for Work Program 2025, please see the Supporting Links in the Further Information section below.
+
+**Fundamental Research**
+
+* **World’s Operating System**
+    * **State-Machine Contract Environment (WOS-2):** This stream simplifies the formal description of smart contracts for Cardano through a formal state-machine framework (EasySM) that abstracts the complexities of the EUTxO model and facilitates verification.
+    * **Location-Based Services and Smart Contracts (WOS-6):** This stream explores how geolocation can enhance smart contracts and node infrastructure, focusing on geographic diversity metrics and incentives for global decentralization.
+* **Ouroboros Omega**
+    * **Ouroboros Peras – Vision (OO-1V):** A first version of Peras has been delivered, showing promising improvements in settlement times, with ongoing research focused on enhancing robustness and avoiding cooldown phases for greater efficiency.
+    * **Ouroboros Leios (OO-2):** Leios introduces vertical scalability to Cardano’s consensus by aligning throughput with node resources, overcoming current limitations in block size and timing.
+    * **Fair Transaction Processing (OO-3):** Develops protocol-level solutions to reduce front-running issues and ensure fair transaction ordering, reducing MEV without compromising decentralization or performance.
+    * **Multi-Resource Consensus – Minotaur (OO-5):** Minotaur explores hybrid consensus mechanisms that combine PoW and PoS (including restake from different PoS networks) to improve security, resilience, and inclusivity—features that further help bootstrapping low-liquidity or early-stage blockchains that rely on Cardano for security.
+    * **Proofs of Useful Work (OO-6):** This stream advances consensus models that replace wasteful PoW with verifiable, valuable computation (including SAT solving, zk-SNARK generation, ML computation, etc.), building on Ofelimos to enhance sustainability and network utility.
+    * **Congestion Control (OO-7):** This research reimagines blockchain fee models by introducing resource- and urgency-based pricing to ensure fair, predictable, and efficient transaction processing under network load.
+* **Tokenomicon**
+    * **Tokenomics Design (TO-1):** This stream develops mathematical models to guide Cardano’s long-term macroeconomic policies, optimizing token circulation and ensuring system stability through evidence-based parameter choices.
+    * **Rewards Sharing and Transaction Fees (TO-2):** Focused on fair and effective incentive design, this stream seeks to improve reward distribution and fee mechanisms to support decentralization, user fairness, and platform competitiveness.
+* **Global identity**
+    * **Decentralized Identity and Reputation (GI-1):** This stream designs a formal, flexible identity framework enabling users to control and share digital credentials securely across platforms, supporting cross-application interoperability and the effective use of identities in protocols.
+* **Democracy 4.0**
+    * **Next-Level Governance Protocols (D4-1):** This workstream develops scalable, decentralized governance systems with secure, low-footprint voting mechanisms suited for future growth and aligned with Cardano’s constitutional principles.
+    * **Governance Incentives (D4-2):** Focused on DReps and beyond, this stream designs incentive schemes that balance effective decision-making with decentralization, transparency, and fairness in Cardano’s evolving governance landscape.
+* **Internet Hydra-ted**
+    * **Hydra Tail (IHT-1):** Hydra Tail enhances Cardano’s layer 2 scaling with zk-rollups, enabling off-chain transaction batching and secure on-chain settlement through succinct zero-knowledge proofs.
+    * **Inter-Head (IHT-2):** This stream extends Hydra to support scalable, multi-party state channels that enable fast, composable layer 2 interactions with minimal on-chain footprint.
+    * **Optimization Tools (IHT-3):** Focused on Hydra network efficiency, this stream develops tools for fund rebalancing, message routing, and synchronization to maximize throughput and resource use.
+    * **Auditing Tools (IHT-4):** This stream introduces optional auditing features for Hydra to balance privacy with accountability, enabling limited, compliant access to off-chain transaction history for institutional clients.
+* **Interchains**
+    * **Light Client Infrastructure (IC-3):** This stream develops secure, efficient, and incentivized light clients to support scalable applications like zk-bridges, addressing device limitations and data asymmetry.
+    * **DApps Tokenomics (IC-4.1):** This research explores tokenomics principles for launching new dApps or partnerchains, focusing on early-stage design for economic stability and adoption.
+    * **Consensus Innovation (IC-4.2):** This stream investigates next-generation consensus protocols—blending Nakamoto and BFT models—to enhance Cardano’s scalability, decentralization, and fault tolerance under dynamic network conditions.
+
+**Technology Validation**
+
+* **Leios:** This stream advances Ouroboros Leios toward implementation by formalizing specifications, modeling performance, analyzing security, and preparing a CIP for high-throughput, real-world deployment on Cardano.
+* **Anti-Grinding:** Focused on reducing settlement times, this stream strengthens anti-grinding protections in Praos and related protocols to increase adversarial costs and improve security.
+* **Jolteon Liveness (formerly fastBFT):** A new high-performance BFT consensus protocol for Partnerchains, delivering formal safety guarantees and competitive finality.
+* **RSnarks:** Enables scalable, privacy-preserving zk-bridges via recursive SNARKs by adapting Halo2 proofs for Cardano verification, enhancing interoperability with other blockchains with foreign pairing check and building Plutus-compatible tooling.
+* **Proof of Restake:** This stream supports secure blockchain launches using hybrid consensus, enabling validators to re-stake from other chains and transition to native stake as adoption grows.
+* **Light Clients Infrastructure:** Aims to enable efficient, low-resource wallet and smart contract interaction, with ongoing research focused on a novel blind signature-based protocol to support decentralized, DApp-friendly infrastructure.
+- **Audit & Oversight Allocation:** 1342400 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
+- **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
+
+## References
+- Constitution Hash: 8c653ee5c9800e6d31e79b5a7f7d4400c81d44717ad4db633dc18d4c07e4a4fd00
+- Approved Net Change Limit Hash: 9b62b3c632f329016a968ac25211825bb4f84b12461121c7da3aa11df92370f900
+- Approved Budget Hash: e14de8d9dc4f4ddf3fe9250a8a926e20f10e99b86bd0610b77d7a054981591ee00
+
+## Budget Reference
+> On behalf of Intersect and the Cardano Budget Committee, this Budget Info Action proposes a Cardano Blockchain Ecosystem Budget of 275,269,340 ada. The period during which this Budget Info Action remains in effect will begin at the close of its voting period and continue for 73 epochs (52 weeks). This budget is an aggregate allocation and following Treasury Withdrawal(s) must be in compliance with an approved and active Net Change Limit, among other conditions. This budget comprises 39 proposals that support maintenance, development, marketing, innovation, and governance initiatives within the Cardano Blockchain Ecosystem.
+
+## Net Change Limit Clause
+> The total requested funding sits below the Net Change Limit (NCL) currently in force, 350 trillion lovelace, or 350 million ada, as of 8 May 2025. Consequently, each subsequent Treasury Withdrawal must be presented and approved only if it remains within the then-active NCL, in line with Article IV of the Cardano Constitution and Guardrail: TREASURY-02a.
+
+## Constitutional Requirements
+
+### Article IV, Section 3
+> Withdrawals from the Cardano Blockchain treasury that would cause the Cardano Blockchain treasury balance to violate the then applicable net change limit shall not be permitted.
+> No withdrawals from the Cardano Blockchain treasury shall be permitted unless such withdrawals have been authorized and are being made pursuant to a budget for the Cardano Blockchain that is then in effect as required by the Cardano Blockchain Guardrails Appendix, and which has not been determined by the Constitutional Committee to be unconstitutional.
+
+### Article IV, Section 4
+> Any governance action requesting ada from the Cardano Blockchain treasury shall require an allocation of ada as a part of such funding request to cover the cost of periodic independent audits and the implementation of oversight metrics as to the use of such ada.
+> Contractual obligations governing the use of ada received from the Cardano Blockchain treasury pursuant to a Cardano Blockchain ecosystem budget shall include dispute resolution provisions.
+
+### Article IV, Section 5
+> Any ada received from a Cardano Blockchain treasury withdrawal, so long as such ada is being held directly or indirectly by an administrator prior to further disbursement, must be kept in one or more separate accounts that can be audited by the Cardano Community, and such accounts shall not be delegated to an SPO but must be delegated to the predefined auto abstain voting option.
+
+### Guardrails on Treasury Withdrawal Actions
+> TREASURY-01a (x) A net change limit for the Cardano treasury's balance per period of time **must** be agreed by the DReps via an on-chain governance action with a threshold of greater than 50% of the active voting stake.
+> TREASURY-02a (x) Withdrawals from the Cardano Blockchain treasury made pursuant to an approved Cardano Blockchain ecosystem budget **must not** exceed the net change limit for the Cardano Treasury's balance per period of time.
+> TREASURY-03a (x) Withdrawals from the Cardano Blockchain treasury **must** be denominated in ada.
+> TREASURY-04a (x) Withdrawals from the Cardano Blockchain treasury **must not** be ratified until there is a Cardano Community approved Cardano Blockchain ecosystem budget then in effect pursuant to a previous on-chain governance action agreed by the DReps with a threshold of greater than 50% of the active voting stake.
+
+## Fund Management & Oversight
+- Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
+- Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/484/treasury_withdrawal.md
+++ b/proposals/484/treasury_withdrawal.md
@@ -1,0 +1,204 @@
+<!--
+Template for Cardano Treasury Withdrawal Proposals
+
+This template combines the constitutional requirements for Treasury Withdrawals
+and the terms established in the approved Budget Info Action.  Replace each
+placeholder ({{...}}) with the appropriate value for each proposal.
+-->
+# Treasury Withdrawal Proposal: Cardano Product Committee: Community-driven 2030 Cardano Vision and 2026 roadmap insights collection via workshops and structured product research
+
+## Withdrawal Details
+- **Amount:** 750,000 ADA (750000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** #### Overview
+
+One of the key community goals in 2025 is to create a shared long-term vision, transitioning from the roadmap created by Cardano’s founders to a community-led dynamic vision and yearly roadmap.
+
+--
+
+To create the first community driven 2030 Cardano vision, and a following 2026 roadmap, the Cardano Product Committee of Intersect, via consultation, has drafted a strategy (which is already operational) which includes both broad consultation via workshops (remote and in-person) and focused insights collection via focus group calls, with key ecosystem stakeholders (like SPOs) and businesses (both in Cardano and outside Cardano), and incentivized structured user and market research with an initial set of broad questions divided by the broad Cardano [goals](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2025-cardanos-roadmap/2025-proposed-cardano-goals).
+
+  
+
+#### About 2030 vision process and in-depth product research
+
+##### 2030 vision process
+
+To draft a community-driven proposed 2030 vision, the Committee has defined a 4-step phases (currently in progress):
+
+1.  Insight Collection
+    
+
+    -   Community workshops (up to 100 globally, online and in-person)
+    
+    -   Collection of qualitative insights on user pain points, ecosystem opportunities, and desired 2030 outcomes
+    
+    -   Documentation and analysis of insights gathered
+    
+
+2.  Drafting the Vision Proposal
+    
+
+    -   Synthesis of insights into key objectives for 2030
+    
+    -   Structuring of broad eras to achieve those objectives
+    
+    -   Incorporation of existing research, SWOT analysis, academic reports, and ecosystem data
+    
+
+3.  Community Review & Iteration
+    
+
+    -   Public virtual workshops to critique the draft vision
+    
+    -   Naming of eras, prioritization of deliverables
+    
+    -   Final refinements based on feedback
+    
+
+4.  On-chain Submission
+    
+
+    -   Ratification via community info action
+    
+    -   Public release of the final vision document and supporting research archive
+    
+
+--
+
+The process above will provide qualitative insights from consultations, which will also be available to the whole community for reference and to act as guidance.  
+To facilitate more and more of these discussions the committee is providing support to run remote workshops, however, knowing how important in-person discussions are when brainstorming a vision, and to collect regional insights, the committee has identified a need to incentivize small gatherings, possibly in existing events, which will generate extremely valuable insights during the first step and great critiques during the third step.
+
+--
+
+In particular, we aim to provide support to local discussions via small rewards up to ADA 500 to anyone who meets in their own region and documents the insights gathered. The local element will emphasise the regional insights and help the committee (and the broader community) to find use cases and opportunities in different regions and markets. We also aim to give support via small rewards of up to ADA 1000 to anyone who will run structured workshops with more than 10 attendees.  
+
+--
+
+Basic acceptance criteria to access these funds will include:
+
+-   Anyone running a small ad-hoc gathering or a structured workshop will need to create a Luma event and add it to the Luma [Product committee calendar](https://lu.ma/intersectProductCommittee)
+    
+-   Send the 2030 Vision consultation [survey](https://forms.gle/nF8YwWBTomvT5scj6)
+    
+-   Hosts of small ad-hoc gatherings need to take notes and compile a report with key insights
+    
+-   Hosts of structured workshops need to ensure participants have access to the provided Miro template, and during the session, they should collect notes as well as compile a report with key insights
+    
+
+--  
+  
+
+Since the end of 2024, the Cardano Product Committee of Intersect has already started to work through this by:
+
+-   Creating a first version of a repeatable process (documented [here](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2030-long-term-cardano-vision))
+    
+-   Opening a wide consultation via survey ([here](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2030-long-term-cardano-vision))
+    
+-   Running open remote, and in-person workshops ([here](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2030-long-term-cardano-vision/insights-collection-workshops))
+    
+-   Running focus groups with SPOs and builders/businesses ([here](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2030-long-term-cardano-vision/focus-group-calls))
+    
+
+  
+
+##### In-depth Product Research
+
+To answer more detailed questions in relation to user needs and market opportunities the committee has collected, via open consultation, an initial set of broad questions which aims to expand and answer by incentivizing and funding the first consolidated user and market research effort in Cardano, creating a framework and opening the way to continuous product insights collection (bringing that to the same quality and standards of Cardano’s academic research).
+
+--
+
+For year 1, 2025, the research conducted aims to provide insights into the direction and refinement of the proposed goals for 2025 and support builders (as well as other committees in Intersect) with information on user needs. In addition to this initial need, the insights from this first year will directly inform the Cardano strategy for 2025 and 2026 and help create a longer-term vision. The outcome of this research will also lead to clear problem statements, which will be documented as Cardano Problem Statements (CPSs).
+
+--
+
+The initiative aims to produce validated Cardano Problem Statements (CPSs), evidence-based recommendations, and qualitative and quantitative user and market insights to reach and get closer to five strategic goals (documented [here](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2025-cardanos-roadmap/2025-proposed-cardano-goals) in more detail):
+
+1.  Get more usage
+    
+2.  Make Cardano easier to build on and use
+    
+3.  Make Cardano a competitive option
+    
+4.  Create clear funding mechanisms
+    
+5.  Make Cardano more recognizable
+    
+--
+
+
+It will also support the underlying vision of creating a shared, community-driven path for Cardano’s growth through 2030. The results will be published in public repository to ensure reusability and transparency. The research will:
+
+-   Identify bottlenecks in tooling, onboarding, and documentation
+    
+-   Validate which use cases Cardano is best suited for (and which it's not)
+    
+-   Map personas and journeys for dApp teams, enterprises, and community members
+    
+-   Clarify gaps in governance awareness and participation
+    
+-   Offer comparative insights from other ecosystems to identify opportunities
+    
+
+--
+
+The Product Committee has analysed and documented in detail, also building on the successful workshop methodologies implemented in Paris, Florida International University, and Japan :
+
+-   [High-level Skillset and expertise](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2025-proposed-research-budget#high-level-skillset-and-expertise-required-1) required to run this research
+    
+-   [Broad acceptance criteria](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2025-proposed-research-budget#broad-acceptance-criteria-1) for the overall Product research effort, which include:
+    
+
+    -   Expert-led, rigorous research
+    
+    -   Transparent and timely dissemination
+    
+    -   Validated and ecosystem-aligned
+    
+
+-   [An initial set of questions](https://productcommittee.docs.intersectmbo.org/committee-outcomes/2025-proposed-research-budget#proposed-items-1) for each of the five broad goals that, once answered, will help determine the most effective direction to take in order to achieve them
+    
+--
+
+
+A comprehensive [survey](https://forms.gle/3smQdwTC1sJh65bs7) and [workshop template](https://miro.com/app/board/uXjVIRNXbrI=/?share_link_id=427321460527) optimized for gathering broader insights with a strong focus on regional nuances, as demonstrated by the success in the initial workshops
+- **Audit & Oversight Allocation:** 37500 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
+- **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
+
+## References
+- Constitution Hash: 8c653ee5c9800e6d31e79b5a7f7d4400c81d44717ad4db633dc18d4c07e4a4fd00
+- Approved Net Change Limit Hash: 9b62b3c632f329016a968ac25211825bb4f84b12461121c7da3aa11df92370f900
+- Approved Budget Hash: e14de8d9dc4f4ddf3fe9250a8a926e20f10e99b86bd0610b77d7a054981591ee00
+
+## Budget Reference
+> On behalf of Intersect and the Cardano Budget Committee, this Budget Info Action proposes a Cardano Blockchain Ecosystem Budget of 275,269,340 ada. The period during which this Budget Info Action remains in effect will begin at the close of its voting period and continue for 73 epochs (52 weeks). This budget is an aggregate allocation and following Treasury Withdrawal(s) must be in compliance with an approved and active Net Change Limit, among other conditions. This budget comprises 39 proposals that support maintenance, development, marketing, innovation, and governance initiatives within the Cardano Blockchain Ecosystem.
+
+## Net Change Limit Clause
+> The total requested funding sits below the Net Change Limit (NCL) currently in force, 350 trillion lovelace, or 350 million ada, as of 8 May 2025. Consequently, each subsequent Treasury Withdrawal must be presented and approved only if it remains within the then-active NCL, in line with Article IV of the Cardano Constitution and Guardrail: TREASURY-02a.
+
+## Constitutional Requirements
+
+### Article IV, Section 3
+> Withdrawals from the Cardano Blockchain treasury that would cause the Cardano Blockchain treasury balance to violate the then applicable net change limit shall not be permitted.
+> No withdrawals from the Cardano Blockchain treasury shall be permitted unless such withdrawals have been authorized and are being made pursuant to a budget for the Cardano Blockchain that is then in effect as required by the Cardano Blockchain Guardrails Appendix, and which has not been determined by the Constitutional Committee to be unconstitutional.
+
+### Article IV, Section 4
+> Any governance action requesting ada from the Cardano Blockchain treasury shall require an allocation of ada as a part of such funding request to cover the cost of periodic independent audits and the implementation of oversight metrics as to the use of such ada.
+> Contractual obligations governing the use of ada received from the Cardano Blockchain treasury pursuant to a Cardano Blockchain ecosystem budget shall include dispute resolution provisions.
+
+### Article IV, Section 5
+> Any ada received from a Cardano Blockchain treasury withdrawal, so long as such ada is being held directly or indirectly by an administrator prior to further disbursement, must be kept in one or more separate accounts that can be audited by the Cardano Community, and such accounts shall not be delegated to an SPO but must be delegated to the predefined auto abstain voting option.
+
+### Guardrails on Treasury Withdrawal Actions
+> TREASURY-01a (x) A net change limit for the Cardano treasury's balance per period of time **must** be agreed by the DReps via an on-chain governance action with a threshold of greater than 50% of the active voting stake.
+> TREASURY-02a (x) Withdrawals from the Cardano Blockchain treasury made pursuant to an approved Cardano Blockchain ecosystem budget **must not** exceed the net change limit for the Cardano Treasury's balance per period of time.
+> TREASURY-03a (x) Withdrawals from the Cardano Blockchain treasury **must** be denominated in ada.
+> TREASURY-04a (x) Withdrawals from the Cardano Blockchain treasury **must not** be ratified until there is a Cardano Community approved Cardano Blockchain ecosystem budget then in effect pursuant to a previous on-chain governance action agreed by the DReps with a threshold of greater than 50% of the active voting stake.
+
+## Fund Management & Oversight
+- Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
+- Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/486/treasury_withdrawal.md
+++ b/proposals/486/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Ledger App Rewrite
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 300,000 ADA (300000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Work with Ledger team to design new UI according to the expectations. Implement new UI into the Cardano Ledger App. Pass the external audit process (costs for this shall be included in proposal). Support the Ledger team by the release process.
+- **Audit & Oversight Allocation:** 15000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/5/treasury_withdrawal.md
+++ b/proposals/5/treasury_withdrawal.md
@@ -5,16 +5,24 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Hardware Wallets Maintenance
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 424,800 ADA (424800000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Update Ledger and Trezor firmware and integration libraries with new relevant Cardano features or breaking changes. Update also if there are any breaking changes in Ledger and Trezor core firmware code, testing suites, etc.
+
+Update cardano-hw-cli to reflect firmware changes and to reflect user needs
+
+Support Keystone developers while doing the changes above
+
+Provide general cardano hw wallets maintenance, development support and bugfixing.
+
+Order and manage external code audits for Ledger firmware code (Ledger requirement, has to be done by one of 2 certified auditors)
+- **Audit & Oversight Allocation:** 21240 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +58,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/502/treasury_withdrawal.md
+++ b/proposals/502/treasury_withdrawal.md
@@ -5,16 +5,29 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Scalus - DApps Development Platform
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 657,692 ADA (657692000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Developing DApps on Cardano shouldn't require juggling multiple languages, libraries and frameworks.
+
+Scalus changes this by bringing the power of Scala 3 to the Cardano ecosystem, letting you write smart contracts, build transactions, and application layers — all with the same language and familiar tools.
+
+It supports the complete development flow - setup, development, testing, debugging and deployment, backed by an industry-grade toolset and professional development experience.
+
+Key benefits that make Scalus + Scala 3 stand out:
+- Productivity boost at scale with Scala 3
+- Reduced time-to-market - from prototyping to production in less time
+- Deep pool of Scala/Java/Kotlin talent available on the market
+
+Scalus is a Cardano DApps development platform made for professionals and businesses who want to get things done.
+
+More details in the attached presentation.
+- **Audit & Oversight Allocation:** 32884 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +63,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/53/treasury_withdrawal.md
+++ b/proposals/53/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: MLabs Core Tool Maintenance & Enhancement: Plutarch
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 243,478 ADA (243478000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** This proposal seeks funding for the ongoing annual maintenance and feature enhancement of Plutarch, a production-grade eDSL in Haskell for creating Cardano smart contracts. As a core tool widely adopted within the ecosystem, Plutarch requires consistent upkeep. Funding covers maintenance (bug fixes, compatibility updates for hardforks) and new feature implementation based on community needs (e.g., via GitHub issues). This ensures Plutarch remains resilient, powerful, and up-to-date, supporting developers and the ecosystem.
+- **Audit & Oversight Allocation:** 12173 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/536/treasury_withdrawal.md
+++ b/proposals/536/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: A free Native Asset CDN for Cardano Developers
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 605,000 ADA (605000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Building reliable infrastructure to display Cardano native assets (NFTs &FTs) efficiently, at scale, can cost upwards of $100,000 and take 9+ months of development effort. **We propose to deliver a free Native Asset Content Delivery Network (CDN) for Cardano, by making our existing NFTCDN services free to use for anyone building on Cardano**. NFTCDN has been operating since 2022 and provides fast, reliable and resilient multimedia and metadata delivery through a globally distributed CDN, enabling projects to display native assets effortlessly. By removing technical and financial barriers, NFTCDN allows developers to focus on product innovation and growth, accelerate time-to-market, and promotes wider adoption and implementation of native assets within apps across the Cardano ecosystem.
+- **Audit & Oversight Allocation:** 30250 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/558/treasury_withdrawal.md
+++ b/proposals/558/treasury_withdrawal.md
@@ -5,16 +5,18 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: zkFold ZK Rollup
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 1,161,000 ADA (1161000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** ZK rollups address the scalability problem. Hundreds of transactions can be submitted as a single batch, reducing the load on the L1. Cardano can achieve higher throughput and lower transaction costs.
+
+zkFold offers to build a general-purpose zero knowledge rollup solution for Cardano. A zero knowledge rollup is a technological layer (Layer 2) on top of a blockchain that increases the blockchain’s scalability potential by compressing many transactions into transaction batches. As batches offer a greater degree of information compression, it is reasonable to expect that hundreds of rollup smart contract transactions might fit into a single Cardano mainnet transaction. Zero knowledge proofs technology places a limit on the cost of on-chain verification of the validity of transaction batches. Specifically, the batch verification fits well within the Execution Unit limits set at the protocol level, as demonstrated by the prototype created by the zkFold team
+- **Audit & Oversight Allocation:** 58050 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +52,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/597/treasury_withdrawal.md
+++ b/proposals/597/treasury_withdrawal.md
@@ -1,0 +1,161 @@
+<!--
+Template for Cardano Treasury Withdrawal Proposals
+
+This template combines the constitutional requirements for Treasury Withdrawals
+and the terms established in the approved Budget Info Action.  Replace each
+placeholder ({{...}}) with the appropriate value for each proposal.
+-->
+# Treasury Withdrawal Proposal: MLabs Research towards Tooling for Elliptical Curves - GrumpleStiltSkin
+
+## Withdrawal Details
+- **Amount:** 104,347 ADA (104347000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** GrumpleStiltSkin will deliver an open-source, parameterized elliptic curve and Galois field framework implemented in Plutarch. The goal is to allow smart contracts on Cardano to verify cryptographic proofs over customizable curves and fields. This will include:
+Plutarch support for Galois field arithmetic
+
+
+Plutarch support for elliptic curve arithmetic
+
+
+A generic ZK verifier in Plutarch
+
+
+A validation test suite over BLS12-381
+
+
+A composable YTxP-compatible Plutarch wrapper
+
+
+This tool empowers developers with on-chain cryptographic flexibility, expands Cardano’s ZK application capabilities, and sets the stage for future innovations in privacy and authentication.
+
+# Introduction
+
+Elliptic curves, specifically over Galois
+fields, have found multiple uses in blockchain applications. 
+One particularly significant application is zero-knowledge proofs, which promise
+significant capability enhancements, ranging from better onchain performance to
+new operations. To this end, a whole constellation of different elliptic curves,
+based on a huge range of Galois fields, have been proposed and designed. These
+vary in their mathematical properties, intended use cases, and other features,
+while still being broadly similar in terms of their basic foundations. Such
+curves include, but aren't limited to:
+
+* The Pasta curves
+* The Grumpkin curve
+* BLS12-381
+
+This list is not complete, and is likely to grow larger as time passes. In
+general, every blockchain, and its respective software ecosystem, tends to
+settle on a different choice of elliptic curve(s) and associated Galois fields.
+
+Plutus is no exception to this. Currently, there are no fewer than eight CIPs, in
+various stages of adoption, which either directly, or indirectly, justify their
+proposed extensions to Plutus by way of elliptic curves, finite field
+arithmetic, or both:
+
+* [CIP-0049]
+* [CIP-0058]
+* [CIP-0101]
+* [CIP-0121]
+* [CIP-0122]
+* [CIP-0123]
+* [CIP-0133]
+* [CIP-0381]
+ 
+These proposals are self-evidently useful, as shown by most of them being
+adopted into Plutus Core. However, for an application developer who wants to
+work over a specific elliptic curve, all of these proposed improvements suffer
+from one of two problems. 
+
+The first of these problems, as typified by CIP-0058, is an excess of
+generality. You are given the pieces to (possibly) build the curve functionality
+you need, but no help beyond that. This means a lot of work, likely involving
+expertise (and concerns) far outside your domain of interest or knowledge.
+Furthermore, you now become responsible for security considerations around
+elliptic curve use. Lastly, if multiple application developers need logic around
+a specific curve, this may end up being re-implemented multiple times by
+different teams. None of these make the process _straightforward_, and in many
+cases might be a hard obstacle to a working product even if it's technically
+possible.
+
+The second problem, typified by CIP-0381, is an excess of specificity. If an
+application developer wants to work over a specifically-supported curve (such as
+BLS12-381 in this case), this is a blessing from the correctness, optimization
+and security point of view. However, if this isn't the curve they need, they are
+left out in the cold. While it is conceivable for an application developer to
+request the curve they need to have direct support in Plutus Core similar to
+BLS12-381, this is impractical at best, and creates all the issues discussed
+previously regarding incidental complexity and requiring expertise from other
+domains.
+
+Furthermore, there is an unspoken problem of having application developers being
+forced to own the underlying primitives for their curve implementations. If
+issues of performance or security are discovered, or even if some more
+operations or generality are needed, the application developers must provide the
+upgrade path. This can range from difficult to impossible, and must be
+engineered for ahead of time. This just compounds the difficulties involved,
+especially for developers who are not experts in either cryptographic security
+or onchain performance.
+
+# Our solution
+
+We will create a two-part proof-of-concept system, named Grumpelstilskin, designed 
+to allow application developers to easily use any curve of their choice for
+zero-knowledge proof verification on-chain. The first part of Grumpelstilskin
+will be a 'working script' which, when given appropriate parameters via its
+datum, will verify a zero-knowledge proof over a user-specified curve. This
+script will be tested for correctness.
+
+The second part of Grumpelstiltskin will be a YTxP-based interface to
+the 'working script', implemented in Plutarch. This interface will be
+well-documented, easy to use, and flexible, with a focus of making life easy for
+application developers who want to use zero-knowledge proofs. Thanks to our use
+of YTxP, future performance, security and functionality improvements will not be
+the responsibility of application developers who use Grumpelstilskin. This
+second part will be distributed as an open-source project. 
+
+We aim to build a minimum viable product, with the future goals of expanded
+functionality, improved performance, as well as a full audit of the 'working
+script'. Our choice of YTxP will make it minimally difficult to achieve this,
+and will impose minimal friction on any application developers using
+Grumpelstiltskin to build their products.
+- **Audit & Oversight Allocation:** 5217 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
+- **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
+
+## References
+- Constitution Hash: 8c653ee5c9800e6d31e79b5a7f7d4400c81d44717ad4db633dc18d4c07e4a4fd00
+- Approved Net Change Limit Hash: 9b62b3c632f329016a968ac25211825bb4f84b12461121c7da3aa11df92370f900
+- Approved Budget Hash: e14de8d9dc4f4ddf3fe9250a8a926e20f10e99b86bd0610b77d7a054981591ee00
+
+## Budget Reference
+> On behalf of Intersect and the Cardano Budget Committee, this Budget Info Action proposes a Cardano Blockchain Ecosystem Budget of 275,269,340 ada. The period during which this Budget Info Action remains in effect will begin at the close of its voting period and continue for 73 epochs (52 weeks). This budget is an aggregate allocation and following Treasury Withdrawal(s) must be in compliance with an approved and active Net Change Limit, among other conditions. This budget comprises 39 proposals that support maintenance, development, marketing, innovation, and governance initiatives within the Cardano Blockchain Ecosystem.
+
+## Net Change Limit Clause
+> The total requested funding sits below the Net Change Limit (NCL) currently in force, 350 trillion lovelace, or 350 million ada, as of 8 May 2025. Consequently, each subsequent Treasury Withdrawal must be presented and approved only if it remains within the then-active NCL, in line with Article IV of the Cardano Constitution and Guardrail: TREASURY-02a.
+
+## Constitutional Requirements
+
+### Article IV, Section 3
+> Withdrawals from the Cardano Blockchain treasury that would cause the Cardano Blockchain treasury balance to violate the then applicable net change limit shall not be permitted.
+> No withdrawals from the Cardano Blockchain treasury shall be permitted unless such withdrawals have been authorized and are being made pursuant to a budget for the Cardano Blockchain that is then in effect as required by the Cardano Blockchain Guardrails Appendix, and which has not been determined by the Constitutional Committee to be unconstitutional.
+
+### Article IV, Section 4
+> Any governance action requesting ada from the Cardano Blockchain treasury shall require an allocation of ada as a part of such funding request to cover the cost of periodic independent audits and the implementation of oversight metrics as to the use of such ada.
+> Contractual obligations governing the use of ada received from the Cardano Blockchain treasury pursuant to a Cardano Blockchain ecosystem budget shall include dispute resolution provisions.
+
+### Article IV, Section 5
+> Any ada received from a Cardano Blockchain treasury withdrawal, so long as such ada is being held directly or indirectly by an administrator prior to further disbursement, must be kept in one or more separate accounts that can be audited by the Cardano Community, and such accounts shall not be delegated to an SPO but must be delegated to the predefined auto abstain voting option.
+
+### Guardrails on Treasury Withdrawal Actions
+> TREASURY-01a (x) A net change limit for the Cardano treasury's balance per period of time **must** be agreed by the DReps via an on-chain governance action with a threshold of greater than 50% of the active voting stake.
+> TREASURY-02a (x) Withdrawals from the Cardano Blockchain treasury made pursuant to an approved Cardano Blockchain ecosystem budget **must not** exceed the net change limit for the Cardano Treasury's balance per period of time.
+> TREASURY-03a (x) Withdrawals from the Cardano Blockchain treasury **must** be denominated in ada.
+> TREASURY-04a (x) Withdrawals from the Cardano Blockchain treasury **must not** be ratified until there is a Cardano Community approved Cardano Blockchain ecosystem budget then in effect pursuant to a previous on-chain governance action agreed by the DReps with a threshold of greater than 50% of the active voting stake.
+
+## Fund Management & Oversight
+- Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
+- Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/600/treasury_withdrawal.md
+++ b/proposals/600/treasury_withdrawal.md
@@ -5,16 +5,39 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Expanding Stablecoin / Cardano Native Asset Support / Fiat Ramps
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 4,000,000 ADA (4000000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** The Cardano blockchain has emerged as a leading smart contract platform, offering scalability, security, and sustainability. However, despite its technological advantages, Cardano faces critical challenges in mainstream adoption, particularly in the areas of stablecoin liquidity, wallet support for native assets, exchange availability, and fiat on/off-ramps. These limitations hinder Cardano’s ability to compete with other major blockchains in real-world financial applications.
+This proposal seeks funding to address these challenges by:
+1. Expanding wallet and custodian support for Cardano native assets (including USDA, a Cardano-native stablecoin).
+2. Increasing the availability of Cardano stablecoins and native assets on exchanges and OTC desks.
+3. Driving real-world utility for USDA in cross-border payments, remittances, and enterprise settlements.
+4. Building cost-effective fiat on/off-ramps for ADA and Cardano native assets in frontier markets.
+By addressing these challenges, we aim to boost liquidity, accessibility, and adoption of Cardano’s DeFi and real-world use cases, bridging traditional finance with our open source blockchain-based payments 
+
+Problem Statements & Proposed Solutions
+1. Custody & Wallet Gaps: Cardano native assets lack support from institutional custodians like BitGo and Fireblocks, limiting exchange listings and adoption.
+Solution: Partner with custodians to integrate USDA and other assets, enable institutional-grade custody, and expand wallet compatibility.
+Impact: Boosted liquidity, institutional access, and DeFi growth.
+
+2. Exchange & OTC Access: Cardano assets remain underrepresented on CEXs and OTC desks, restricting liquidity and accessibility.
+Solution: Secure Exchange USDA listings (spot and derivatives), form OTC partnerships, and integrate with Neo Banks.
+Impact: Better price discovery, increased trading pairs, enhanced fiat liquidity, and wider market participation.
+
+3. Real-World Utility: Stablecoin use is mostly limited to crypto trading, despite Cardano’s efficient fee model.
+Solution: Enable B2B payments, remittances, payroll, and bill payments using USDA.
+Impact: Broader adoption beyond DeFi and stronger traditional finance integration.
+
+4. Fiat On/Off-Ramps: Users face high-cost (Fiat to ADA), limited access to convert ADA/native assets into fiat.
+Solution: Deploy low-cost onramps via bank transfers/mobile wallets; expand offramps (piloted via Yoroi).
+Impact: Reduced friction, deeper liquidity, and increased financial inclusion.
+- **Audit & Oversight Allocation:** 200000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +73,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/620/treasury_withdrawal.md
+++ b/proposals/620/treasury_withdrawal.md
@@ -5,16 +5,56 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: High-yield RWA Asset for Cardano : Tokenized Real Estate
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 3,000,000 ADA (3000000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Haus is building an open-source Tokenized Home Equity Liquidity Protocol to unlock the $16 trillion in illiquid home equity sitting in U.S. residential real estate. By leveraging blockchain technology, our platform enables homeowners to sell fractional ownership of their home equity, instantly accessing liquidity while allowing investors to gain exposure to real estate appreciation.
+
+We have already prototyped and deployed this model on a private Ethereum blockchain, securing $20 million in Total Value Locked (TVL). With this proposal, we aim to transition HausCoin and the liquidity protocol to Cardano, leveraging its secure, scalable, and cost-effective infrastructure to power a decentralized marketplace for home equity trading.
+
+## Proposal Scope & Objectives
+
+### Tokenizing Home Equity on Cardano:
+- Haus will move its existing liquidity protocol onto Cardano’s mainnet, allowing homeowners to tokenize and sell portions of their home equity directly to investors.  
+- This will create an efficient and scalable real estate-backed asset class, providing homeowners with cash liquidity and investors with a share in home appreciation.
+
+### Launching HausCoin on Cardano:
+- Haus will issue HausCoin, a real estate-backed token enabling home equity trading at scale.  
+- Investors will be able to buy, sell, and trade tokenized real estate assets, unlocking new DeFi use cases for real-world assets (RWAs).
+
+### Leveraging an Existing 30,000-User Waitlist ($4.1B in TVL):
+- Haus already has a 30,000-person waitlist representing $4.1 billion in Total Home Equity Value (TVL).  
+- A fraction of this TVL will be onboarded to Cardano, driving real-world adoption of the protocol.
+
+### Building a Legal Framework for Compliance:
+- Haus will develop a regulatory-compliant framework for issuing and trading tokenized real estate in the U.S., EU and international markets.  
+- Legal and financial structuring will ensure seamless integration with traditional real estate markets.
+
+### Deploying Liquidity Pools & Market Infrastructure:
+- Haus will establish liquidity pools to facilitate instant trading and lending of home equity tokens.  
+- This will support DeFi integration, enabling real estate-backed lending, yield farming, and staking mechanisms.
+
+### Product Completion & Market Expansion:
+- Funding will be used to finalize product development, enhance the user experience, and integrate with key blockchain ecosystems.  
+- Haus will drive market adoption through strategic partnerships, marketing, and investor outreach.
+
+## Why Cardano?
+
+Cardano’s blockchain infrastructure offers a secure, scalable, and cost-effective environment for tokenized assets. By migrating our home equity liquidity protocol and HausCoin to Cardano, we unlock:
+
+- Low-cost transactions for seamless trading and fractional ownership.  
+- Smart contract security for compliant real estate tokenization.  
+- DeFi compatibility, enabling home equity-backed lending and staking.
+
+## Impact & Vision
+
+Haus is pioneering the future of real estate tokenization, transforming home equity into a liquid, tradeable asset class. By launching on Cardano, we aim to bring institutional-grade real estate investing to blockchain, opening new opportunities for homeowners, investors, and the broader DeFi ecosystem.
+- **Audit & Oversight Allocation:** 150000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +90,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/623/treasury_withdrawal.md
+++ b/proposals/623/treasury_withdrawal.md
@@ -5,16 +5,25 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: PyCardano
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 314,800 ADA (314800000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** PyCardano is a lightweight Python library that enables developers to interact seamlessly with the Cardano blockchain. It facilitates the creation and signing of transactions without reliance on external serialization tools, thereby simplifying the development process and broadening accessibility for Python developers. Given the dynamic nature of blockchain technology, particularly with Cardano's ongoing protocol upgrades and hard forks, it is imperative to maintain and update PyCardano to ensure continuous compatibility and functionality.​
+
+
+This proposal aims to:
+
+Ensure Compatibility: Regularly update PyCardano to align with the latest Cardano ledger rules and protocol changes, including upcoming hard forks in 2025.​
+
+Enhance Reliability: Promptly identify and resolve bugs within PyCardano to maintain a robust and dependable library for developers for 12 months since the proposal is funded.​
+
+Foster Community Engagement: Collaborate with the Cardano developer community to gather feedback, address issues, and implement improvements effectively.
+- **Audit & Oversight Allocation:** 15740 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +59,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/637/treasury_withdrawal.md
+++ b/proposals/637/treasury_withdrawal.md
@@ -5,16 +5,19 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: ZK Bridge
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 700,000 ADA (700000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Our proposal is building a ZK bridge for Cardano, which we will deploy on the Cardano testnet.
+As part of this initiative, we will define a communication protocol for the bridge, provide the full source code of the smart contracts on the Cardano side, and produce comprehensive technical documentation detailing the protocol between Cardano and any other isomorphic blockchain. 
+We will provide a circuit that enables a relayer to generate the ZK proof that a locking transaction was successfully added to the chain, which can then be verified on the receiving blockchain. This way, any blockchain will be able to implement a ZK bridge with Cardano, leveraging its newly added capability to generate such proofs. This allows for a variety of uses, such as moving assets outside Cardano just by providing the proof that they’ve locked an equivalent amount in the Cardano Smart Contract. The resulting bridge can serve as a generic framework for interoperability between Cardano and any other blockchain willing to implement the corresponding counterpart contracts.
+Furthermore, we will implement contracts in Aiken to mint assets on a Cardano-like (isomorphic) blockchain and deploy them on the Cardano testnet, providing a fully functional proof of concept. These building blocks will enable developers to create bridges between Cardano and other chains with minimal additional effort.
+- **Audit & Oversight Allocation:** 35000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +53,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/638/treasury_withdrawal.md
+++ b/proposals/638/treasury_withdrawal.md
@@ -5,16 +5,72 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Ecosystem Exchange Listing and Market Making service pool
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 3,126,000 ADA (3126000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Flowdesk acts as a reference party that helps with engineering liquidity provision and listing of CNTs, assisting in:
+
+1- Exchange Listing Fee Pool: 
+
+Eligible exchanges are Kraken, Bybit, Okex and Binance (only top tier exchanges that are requiring new technical integration of CNT)
+
+Budget: Up to 1,500,000 USD (3m ADA at a reference price of 0.5 USD / ADA).
+
+Notes:
+- Top-tier exchanges might ask a listing fee > 500,000 USD. An indicative quote from one top-tier exchange would be around 1m USD of token allocation.
+- Not more than 500k USD (1m ADA) will be allocated for 1 CNT / Exchange.
+- Flowdesk acts as an actor of good faith to validate the budget allocated to a Cardano project for a listing.
+- Flowdesk does NOT receive any funds from the Intersect budget during this process (including no transaction fee, commission fee, etc.).
+- Flow for a Cardano project to request funds to get listed on an exchange:
+
+=> 1 Cardano project with a CNT
+
+=> Project agrees with the exchange on a listing offer
+
+=> Flowdesk Exchange Listing Criteria Assessment
+
+=> Decision
+
+=> If successful, exchange directly receives funding from Intersect for listing the CNT
+
+=> CNT is listed on the exchange.
+
+
+
+
+
+
+2- Market Making Fee Pool: 
+
+Eligible tokens are:
+
+-Non stable coins: SNEK, IAG, MIN and HOSKY
+
+-Stable coins: USDM, USDA, iUSD, DJED, KINKA (gold backed)
+
+
+Budget: 63,000 USD (126,000 ADA at a reference price of 0.5 USD / ADA).
+
+
+Notes:
+
+- Intersect > Cardano Project > pays Flowdesk monthly retainer for MMAAS business.
+- Flowdesk does NOT receive any funds from the Intersect budget during this process (including no transaction fee, commission, etc.).
+
+- Flow for a Cardano project to request funds for MMAAS with Flowdesk:
+
+=> Cardano projects
+=> Project agrees with Flowdesk on a MMAAS offering
+
+=> Cardano project receives funding from Intersect
+
+=> Flowdesk launches the MMAAS service.
+- **Audit & Oversight Allocation:** 156300 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +106,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/645/treasury_withdrawal.md
+++ b/proposals/645/treasury_withdrawal.md
@@ -1,0 +1,233 @@
+<!--
+Template for Cardano Treasury Withdrawal Proposals
+
+This template combines the constitutional requirements for Treasury Withdrawals
+and the terms established in the approved Budget Info Action.  Replace each
+placeholder ({{...}}) with the appropriate value for each proposal.
+-->
+# Treasury Withdrawal Proposal: Complement Catalyst: Extended Quadratic Funding—Zero Operational Costs
+
+## Withdrawal Details
+- **Amount:** 1,500,000 ADA (1500000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** ### Introduction
+
+The Cardano ecosystem stands at a crucial point in its evolution. Having allocated over $150 million through Project Catalyst to fund 2,161 projects, we have witnessed both the remarkable potential and inherent challenges of our current funding mechanisms—challenges common across all blockchain ecosystems. 
+
+As Cardano matures, so too must our approach to fostering innovation and allocating resources within the ecosystem.
+
+This proposal introduces Extended Quadratic Funding (EQF) as a complementary funding mechanism to Project Catalyst—designed not to replace but to enhance Cardano's innovation landscape by addressing five critical limitations in the current system: centralized voting power, limited treasury resources, inadequate impact reporting, unclear return on investment, and inefficient milestone management.
+
+Extended Quadratic Funding combines the mathematical elegance of quadratic voting with reputation-based mechanisms and decentralized governance to create a more equitable, efficient, and sustainable funding ecosystem. Our approach draws inspiration from successful quadratic funding implementations in other blockchain ecosystems while incorporating unique elements tailored to Cardano's specific needs and values.
+
+### The Current Landscape: Achievements and Limitations of Project Catalyst
+
+Project Catalyst represents one of the largest decentralized innovation funds in the blockchain space, demonstrating Cardano's commitment to community-driven development. Through multiple funding rounds, it has supported a diverse array of projects spanning DeFi protocols, educational initiatives, infrastructure improvements, and real-world applications.
+
+However, as the ecosystem has grown, several structural limitations have become increasingly apparent which are common in all blockchain ecosystems:
+
+### 1. Centralized Voting Power
+
+Recent research by Nelson et al. (2024) has quantified what many community members have observed anecdotally: voting power in Project Catalyst is highly concentrated. Their analysis revealed that in 97.5% of voting coalition scenarios, just 1.5% of wallets could determine the final outcome. This concentration reached its apex in Fund 13, where a single entity effectively controlled most funding decisions.
+
+This concentration creates several problems:
+
+- **Narrowed Innovation Focus**: When funding decisions reflect the interests of a few large stakeholders, we risk prioritizing certain types of projects while neglecting others that might better serve the broader ecosystem.
+- **Diminished Participation Incentives**: Small token holders have little motivation to participate in governance when their votes rarely influence outcomes.
+- **Vulnerability to Capture**: Concentrated decision-making power creates potential vulnerabilities to special interests that may not align with the ecosystem's long-term health.
+- **Inconsistency with Cardano's Philosophy**: The current voting mechanism contradicts Cardano's foundational commitment to decentralization and broad-based governance.
+
+### 2. Limited Treasury Resources
+
+Every blockchain ecosystem has a finite treasury. As ecosystems grow and funding demands increase, treasuries face mounting pressure. The current model's exclusive reliance on treasury funds—without additional capital sources—limits both the number and scope of projects that can receive support.
+
+Furthermore, the all-or-nothing approach to project funding creates inefficiencies: projects either receive their requested amount or nothing at all, lacking mechanisms for partial funding based on broader community support.
+
+### 3. Inadequate Impact Reporting
+
+Like all innovation funding systems, Project Catalyst faces challenges in establishing standardized mechanisms to track and report the impact of funded projects. 
+
+This creates several challenges:
+
+- **Difficulty Measuring ROI**: Without consistent metrics, it's nearly impossible to evaluate the return on investment for ecosystem funds.
+- **Limited Learning Opportunities**: The absence of standardized impact data prevents the community from identifying successful funding patterns that could inform future allocations.
+- **Reduced Accountability**: Without transparent reporting requirements, funded teams have limited incentives to maximize their projects' ecosystem impact.
+- **Undermined Community Trust**: The lack of clear impact evidence can erode stakeholder confidence in the funding process over time.
+
+### 4. Unclear Return on Investment
+
+The current funding model operates as a one-way flow of resources: treasury funds are allocated to projects without mechanisms for value to flow back to the ecosystem. While this grant-based approach is appropriate for many public goods, it fails to capture potential value from successful commercial projects that achieve significant traction or profitability.
+
+This limitation:
+
+- Reduces the treasury's long-term sustainability
+- Fails to maximize the ecosystem's return on successful projects
+- Creates a potential misalignment of incentives between funded teams and the broader community
+
+### 5. Inefficient Milestone Management
+
+Milestone review processes across the industry, including Project Catalyst have become a significant challenge, with funded teams often waiting months for payments during review periods. These centralized, opaque processes create:
+
+- **Cash Flow Challenges**: Extended payment delays force teams to self-fund development, advantaging well-capitalized teams over bootstrapped innovators.
+- **Project Abandonment**: Payment delays have contributed to numerous teams abandoning funded projects, wasting both treasury resources and development efforts.
+- **Dispute Resolution Inefficiencies**: The current system requires the Catalyst team to mediate all disputes between reviewers and funded proposers, creating a significant administrative burden.
+- **Scaling Limitations**: As the number of funded projects grows, the centralized review process becomes increasingly untenable.
+
+### Extended Quadratic Funding: A New Paradigm
+
+Extended Quadratic Funding addresses these limitations through five interconnected innovations:
+
+### 1. Democratizing Decision-Making
+
+At the core of our proposal is a novel voting mechanism that balances financial contribution with demonstrated community impact. The EQF voting power calculation multiplies:
+
+1. **The square root of the donation amount in USD**
+    - Example: A $9 donation yields 3 votes (√9 = 3)
+    - Example: A $100 donation yields 10 votes (√100 = 10)
+    - Example: A $10,000 donation yields 100 votes (√10,000 = 100)
+2. **Impact Score—a logarithmic representation of reputation**
+    - Ranges from 300 to 850 (similar to credit score systems)
+    - Increases more slowly as score rises (logarithmic scaling)
+
+This dual mechanism ensures that while financial contribution remains important, its influence is both:
+
+- **Mathematically constrained** through the square root function (quadratic scaling)
+- **Balanced by reputation** through the Impact Score multiplier
+
+For example:
+
+- A new community member donating $100 with a baseline Impact Score of 300 would have 10 × 300 = 3,000 voting power
+- An established contributor donating $100 with an Impact Score of 700 would have 10 × 700 = 7,000 voting power
+- A whale donating $10,000 with a baseline Impact Score would have 100 × 300 = 30,000 voting power
+
+This system significantly reduces the plutocratic effect of the current one-coin-one-vote system while maintaining "skin in the game" principles through financial contribution requirements.
+
+### Sybil Resistance
+
+To protect the integrity of this system, we implement robust Sybil resistance through Self-Sovereign Identity (SSI) verification powered by Hyperledger Identus (formerly Atala PRISM). This system:
+
+- Conducts zero-knowledge proof KYC checks to ensure each account represents a unique human
+- Preserves privacy by never storing personal identification information on-chain
+- Creates a one-human-one-account ecosystem without compromising user anonymity
+
+### Anti-Collusion Mechanisms
+
+We employ four complementary strategies to prevent collusion:
+
+1. **Reputation-Based Incentives**: High Impact Score individuals have strong incentives to maintain system integrity, as their accumulated reputation gives them advantages within the ecosystem.
+2. **Graduated Penalties**: Those caught engaging in coordinated voting face escalating consequences:
+    - First offense: Impact Score reduction
+    - Severe or repeated offenses: Permanent platform ban
+    - Since KYC verification is required, banned participants cannot simply create new identities
+3. **Economic Disincentives**: Our fee structure makes vote-splitting unprofitable:
+    - Platform fees decrease with donation size
+    - This makes it more expensive to split funds across multiple accounts
+4. Implement [Connection-Oriented Cluster Matching](https://www.gitcoin.co/blog/leveling-the-field-how-connection-oriented-cluster-matching-strengthens-quadratic-funding)
+    1. **Cluster Detection**: Groups users based on donation patterns and assigns weighted connection values
+    2. **Similarity Scoring**: Analyzes connections between donors to identify related groups
+    3. **Smart Fund Distribution**: Rewards projects with diverse donor bases while limiting funding for closely connected groups
+
+Together, these mechanisms make collusion economically irrational while preserving legitimate voting influence.
+
+### 2. Multiplying Treasury Impact
+
+The Extended Quadratic Funding model transforms the treasury from the sole funding source to a catalytic multiplier of community resources. Here's how it works:
+
+1. The Cardano treasury allocates a predetermined amount to the matching pool (e.g., $1M)
+2. During the funding round, community members make direct donations to projects they support
+3. These donations serve two purposes:
+    - They provide direct funding to projects (projects keep 100% of direct donations)
+    - They determine each project's share of the matching pool
+4. The matching formula allocates treasury funds based on both donation amount and distribution:
+    - Projects with many small donations receive proportionally more matching funds than those with a few large donations
+    - This incentivizes projects to build broad community support rather than courting a few wealthy backers
+
+For example, consider two projects:
+
+- Project A receives 100 donations of $10 each (total: $1,000)
+- Project B receives 1 donation of $1,000 (total: $1,000)
+
+Though both raised the same amount, Project A would receive significantly more from the matching pool due to its broader support base—potentially 10× more. 
+
+This mechanism creates powerful incentives:
+
+- **For donors**: Even small donations significantly boost a project's matching allocation
+- **For projects**: Building community support becomes as important as securing large contributions
+- **For the treasury**: Each allocated ADA potentially mobilizes additional external capital
+
+U.S. donors gain an additional benefit through our 501(c)(3) structure, making donations tax-deductible—creating unique incentives even outside the cryptocurrency ecosystem.
+
+### 3. Standardized Impact Reporting
+
+All projects funded through the Extended Quadratic Funding mechanism must participate in standardized impact reporting. This includes:
+
+1. **Mandatory Impact Accounting**: Each funded project must allocate a small portion of their funding to contract with a designated impact accountant from an approved pool.
+2. **Standardized Metrics**: All projects report a core set of ecosystem impact metrics:
+    - On-chain transactions generated
+    - New wallets created
+    - Active users acquired
+    - Project-specific KPIs aligned with proposal goals
+3. **Regular Reporting Cadence**: Metrics are reported on a standardized schedule:
+    - Quarterly reports for one year after project completion
+    - Annual reports for commercial projects with revenue-sharing agreements
+4. **Public Dashboard**: All impact metrics are published on a public dashboard, creating unprecedented transparency into the outcomes of funded innovation.
+
+This comprehensive reporting system enables:
+
+- **Data-Driven Decisions**: Future funding rounds can be informed by concrete impact data
+- **Pattern Recognition**: The community can identify which types of projects deliver the highest ROI
+- **Accountability**: Funded teams have clear incentives to demonstrate meaningful ecosystem impact
+- **Learning Opportunities**: Unsuccessful projects provide valuable insights alongside successes
+
+### 4. Sustainable Value Capture
+
+To ensure long-term treasury sustainability, we implement a voluntary contribution system where funded projects that achieve commercial success share value with the ecosystem. This operates through several mechanisms:
+
+1. **Equity Agreements**: Commercial startups can offer a small equity stake (typically 1-3%)
+2. **Token Allocations**: Projects launching tokens can allocate a portion to the ecosystem (typically 2-5%)
+3. **Revenue Sharing**: Commercial applications can contribute a percentage of revenue (typically 1-3%)
+4. **Alternative Value**: Some projects may contribute other assets like carbon credits or data access
+
+These contributions flow into a dedicated treasury separate from the main Cardano treasury but governed by the same community. This creates a virtuous cycle where successful projects help fund future innovation.
+
+Our target is to achieve an annual 5% ROI within 10 years across the entire portfolio. While ambitious, this benchmark is actually conservative compared to traditional venture capital expectations, reflecting our balanced approach to funding both public goods and commercial applications.
+- **Audit & Oversight Allocation:** 75000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
+- **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
+
+## References
+- Constitution Hash: 8c653ee5c9800e6d31e79b5a7f7d4400c81d44717ad4db633dc18d4c07e4a4fd00
+- Approved Net Change Limit Hash: 9b62b3c632f329016a968ac25211825bb4f84b12461121c7da3aa11df92370f900
+- Approved Budget Hash: e14de8d9dc4f4ddf3fe9250a8a926e20f10e99b86bd0610b77d7a054981591ee00
+
+## Budget Reference
+> On behalf of Intersect and the Cardano Budget Committee, this Budget Info Action proposes a Cardano Blockchain Ecosystem Budget of 275,269,340 ada. The period during which this Budget Info Action remains in effect will begin at the close of its voting period and continue for 73 epochs (52 weeks). This budget is an aggregate allocation and following Treasury Withdrawal(s) must be in compliance with an approved and active Net Change Limit, among other conditions. This budget comprises 39 proposals that support maintenance, development, marketing, innovation, and governance initiatives within the Cardano Blockchain Ecosystem.
+
+## Net Change Limit Clause
+> The total requested funding sits below the Net Change Limit (NCL) currently in force, 350 trillion lovelace, or 350 million ada, as of 8 May 2025. Consequently, each subsequent Treasury Withdrawal must be presented and approved only if it remains within the then-active NCL, in line with Article IV of the Cardano Constitution and Guardrail: TREASURY-02a.
+
+## Constitutional Requirements
+
+### Article IV, Section 3
+> Withdrawals from the Cardano Blockchain treasury that would cause the Cardano Blockchain treasury balance to violate the then applicable net change limit shall not be permitted.
+> No withdrawals from the Cardano Blockchain treasury shall be permitted unless such withdrawals have been authorized and are being made pursuant to a budget for the Cardano Blockchain that is then in effect as required by the Cardano Blockchain Guardrails Appendix, and which has not been determined by the Constitutional Committee to be unconstitutional.
+
+### Article IV, Section 4
+> Any governance action requesting ada from the Cardano Blockchain treasury shall require an allocation of ada as a part of such funding request to cover the cost of periodic independent audits and the implementation of oversight metrics as to the use of such ada.
+> Contractual obligations governing the use of ada received from the Cardano Blockchain treasury pursuant to a Cardano Blockchain ecosystem budget shall include dispute resolution provisions.
+
+### Article IV, Section 5
+> Any ada received from a Cardano Blockchain treasury withdrawal, so long as such ada is being held directly or indirectly by an administrator prior to further disbursement, must be kept in one or more separate accounts that can be audited by the Cardano Community, and such accounts shall not be delegated to an SPO but must be delegated to the predefined auto abstain voting option.
+
+### Guardrails on Treasury Withdrawal Actions
+> TREASURY-01a (x) A net change limit for the Cardano treasury's balance per period of time **must** be agreed by the DReps via an on-chain governance action with a threshold of greater than 50% of the active voting stake.
+> TREASURY-02a (x) Withdrawals from the Cardano Blockchain treasury made pursuant to an approved Cardano Blockchain ecosystem budget **must not** exceed the net change limit for the Cardano Treasury's balance per period of time.
+> TREASURY-03a (x) Withdrawals from the Cardano Blockchain treasury **must** be denominated in ada.
+> TREASURY-04a (x) Withdrawals from the Cardano Blockchain treasury **must not** be ratified until there is a Cardano Community approved Cardano Blockchain ecosystem budget then in effect pursuant to a previous on-chain governance action agreed by the DReps with a threshold of greater than 50% of the active voting stake.
+
+## Fund Management & Oversight
+- Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
+- Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/68/treasury_withdrawal.md
+++ b/proposals/68/treasury_withdrawal.md
@@ -5,16 +5,18 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Lucid Evolution Maintenance
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 130,903 ADA (130903000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Lucid Evolution is an open-source library designed to simplify and enhance the development of off-chain smart contract interactions on Cardano. As the official maintainer of Lucid, Anastasia Labs is committed to evolving the library to align with the upcoming Chang Hard Fork, ensuring long-term support and usability for developers.
+
+This proposal seeks funding to support ongoing development, maintenance, and ecosystem adoption efforts, including compatibility updates, feature enhancements, and developer documentation. By securing funding, Lucid Evolution will continue to serve as a critical tool for DApp developers, improving accessibility and efficiency within the Cardano ecosystem.
+- **Audit & Oversight Allocation:** 6545 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +52,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/683/treasury_withdrawal.md
+++ b/proposals/683/treasury_withdrawal.md
@@ -5,16 +5,31 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Cardano Summit 2025 and regional tech events
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 6,000,000 ADA (6000000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** The 2025 Cardano Summit strategy features a hybrid event model: a flagship event + four regional events. Each event will have a lead organizer, with collaborative support from all partners. To ensure continuity and early planning for 2026, ticket sales will be used for the 2026 summit and its down payment.
+
+A 2-day Cardano Summit for over 800 people. 
+Hosted by the Cardano Foundation in Berlin in Nov 2025 (dates tbc). 
+
+A 2-day Cardano Tech ASIA (name tbd) targeting developers for 300+ people.
+Hosted by EMURGO in Bangalore in December 2025, coinciding with India Blockchain Week. 
+
+A 2-day Cardano Tech AFRICA (name tbd) targeting community and developers for 500 people
+Hosted by Wada in Kenya in September 2025.  
+
+A 2-day Cardano Tech USA (name tbd) targeting developers for 500 people
+Hosted by Rare Evo in Las Vegas on 7 August 2025. 
+
+A 2-day Cardano Tech LATAM (name tbd) targeting developers for 500 people
+Hosted by ADA SOLAR in LATAM October 2025.
+- **Audit & Oversight Allocation:** 300000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +65,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/685/treasury_withdrawal.md
+++ b/proposals/685/treasury_withdrawal.md
@@ -1,0 +1,200 @@
+<!--
+Template for Cardano Treasury Withdrawal Proposals
+
+This template combines the constitutional requirements for Treasury Withdrawals
+and the terms established in the approved Budget Info Action.  Replace each
+placeholder ({{...}}) with the appropriate value for each proposal.
+-->
+# Treasury Withdrawal Proposal: Blockfrost Platform community budget proposal
+
+## Withdrawal Details
+- **Amount:** 1,300,000 ADA (1300000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** # Introduction
+
+Blockfrost is a powerful API platform that gives anyone access to the Cardano Blockchain and functionality without the need to run your own Node.
+
+Our API is designed with developers in mind, and offers tools that remove the complexity of direct node interactions, so anyone can start building on Cardano and launch projects on an afforable, stable and user-friendly framework. 
+
+Blockfrost was originally developed by Five Binaries and is now maintained under the IOG Umbrella.
+
+## Decentralizing Blockfrost
+
+The demand for a reliable infrastructure and tools that support development is what lead to the creating of Blockfrost. If you have interacted witht he Cardano Blockchain, there is a good chance you were interacting with Blockfrost in the background. 
+
+But this level of adoption has come with some trade-offs. At it's peak, Blockfrost was handling over 50% of all on-chain transactions on Cardano. We recognize this concentration is in contrast to the decentralized nature of the blockchain, and have actively been working to decentralize Blockfrost for the benefit of the Cardano community. 
+
+Together with Stake Pool Operators (SPOs) and node operators, we have started the initial phase of what we call the Icebreakers era, an incentivized program designed to decentralize Cardano data access and reward the incredible node operator community.
+
+### The Icebreakers
+
+The Icebreakers is decentralized network of endpoints that allow developers to access Cardano data through a set of reliable node operators, instead of relying on a single centralized source. 
+
+By joining the Icebreaker program, SPOs and other Cardano node operators can monetize their existing infrastructure by processing API requests as part of the Blockfrost network. 
+
+
+## Deliverables
+
+To ensure transparency and to prevent vendor lock-in, we are open-sourcing all components of the deliverables. This includes the infrastructure, libraries and documentation.
+
+Our primary focus on two key projects: The Blockfrost Platform and the Blockfrost Gateway. Both are designed to expand the capabilities of the Icebreaker network. 
+
+### Blockfrost Platform
+
+The Blockfrost platform is a next-generation backend designed to run on existing SPO relays, utilizing existing resources and rewarding operators with a share of Blockfrost's current revenue by serving our existing customers.
+
+### Blockfrost Gateway
+
+The Blockfrost gateway is the entry point for individual SPOs running the Blockfrost platform. Through the gateway, SPOs can receive requests from Blockfrost users. In return for processing these requests, they earn a share of the revenue. 
+
+With the Blockfrost Gateway, anyone can run their own Blockfrost instance with their own platform. We plan to use Hydra to open micro-payment channels between parties, enabling them to exchange ADA or other tokens for their services.  
+
+We are also developing the Solitary mode, which is designed for teams that require full ownership of their enviroment. Developers and enterprise customers can deploy a customized and independent Blockfrost instance with complete control of the infrastructure, uptime and security.  
+
+
+## KPIs
+
+Our proposal follows the milestones outlined in the roadmap below. In addition, we commit to the following KPIs: 
+
+* At least 100 active Icebreakers by end of year, 2025
+* 100% of transactions submitted through Blockfrost will be handled by the Icebreakers by end of year, 2025
+* Quarterly updates provided on the SPO call
+* Monthly community development call
+
+
+## Roadmap & Timelines
+
+The Blockfrost [Roadmap](https://github.com/orgs/blockfrost/projects/17/views/1) ([roadmap view](https://github.com/orgs/blockfrost/projects/17/views/2)) is publically available on our Github and has been structured into distinct eras.
+
+You can also watch the [walkthrough video on our roadmap](https://www.youtube.com/watch?v=5RedwIYmAgc).
+
+All milestones are clearly documented and tracked on our Github roadmap to promote accountability and transparancy. 
+
+#### Icebreakers era
+
+* [Icebreakers: Blockfrost platform initial release](https://github.com/blockfrost/blockfrost-platform/issues/305)
+* [Icebreakers: Transaction submission endpoint](https://github.com/blockfrost/blockfrost-platform/issues/274)
+* [Icebreakers: Platform gateway](https://github.com/blockfrost/blockfrost-platform/issues/276)
+* [Icebreakers: Onboarding](https://github.com/blockfrost/blockfrost-platform/issues/284)
+* [Icebreakers: Live ledger endpoints](https://github.com/blockfrost/blockfrost-platform/issues/275)
+* [Icebreakers: Infrastructure deployment](https://github.com/blockfrost/blockfrost-platform/issues/281)
+* [Icebreakers: Data nodes support](https://github.com/blockfrost/blockfrost-platform/issues/279)
+* [Icebreakers: Conformance testing](https://github.com/blockfrost/blockfrost-platform/issues/304)
+* [Icebreakers: Caching and invalidation](https://github.com/blockfrost/blockfrost-platform/issues/280)
+
+#### Hopper era
+
+* [Hopper: Research into payments channels between the platform and the consumer](https://github.com/blockfrost/blockfrost-platform/issues/287)
+* [Hopper: Hydra payment channels between platform and gateway](https://github.com/blockfrost/blockfrost-platform/issues/277)
+* [Hopper: Hydra payment channel between gateway and consumer](https://github.com/blockfrost/blockfrost-platform/issues/278)
+
+
+## Position with the Cardano Vision and Roadmap for 2025
+
+In March, the majority of DReps voted to adopt the strategic document [Cardano Vision and Roadmap for 2025](https://adastat.net/governances/56f39054758f1a3cedc1de9225d66bf270b62dfdbfbc5399f1d6d43aceffc63600).
+
+Our proposal directly addresses the document's item:
+
+  "Decentralize data API services to reduce reliance on centralized providers and empower SPOs."
+
+We are decentralizing the Blockfrost API and increasing the SPO incentives, at the same time.
+
+## Proposed budget
+
+The majority of our budget is allocated to developer salaries. We are requesting an annual budget of $120,000  to support one full-time employee (FTE).
+
+Our total funding request from the treasury is $650,000, which is equivalent to approximately 1,300,000 ADA based on the current rate of 0.50 USD per ADA.
+
+### Team
+
+The team that is working on the deliverble is as follows:
+
+* [Marek](https://github.com/mmahut): Primary project lead (part-time)
+* [Beatrice](https://github.com/opacular): Community engagement lead and onboarding (part-time)
+* [Vladimir](https://github.com/vladimirvolek): Gateway lead
+* [Michal](https://github.com/michalrus): Platform lead
+* [Sefa](https://github.com/ginnun): Caching lead
+* [Bart](https://github.com/bslabiak): Conformance testing lead
+
+
+This amounts to total of 5 FTEs.
+
+### Audit
+
+Following the completion of the Icebreaker and Hopper eras, we plan to conduct a security audit of the developed code by a trusted third party. We estimate the cost of this audit to be $50,000.
+
+
+## Community Engagement
+
+As part of the budget process, we plan to host several recorded community calls for DReps and other community members to discuss this proposal. 
+
+Records of these calls will be posted in [the Github rendered version of this proposal](https://mmahut-2025budget.blockfrost-platform.pages.dev/budget).
+
+If you have questions that is not addressed in our FAQ or covered in this document, feel free to reach out to the team through our support channels: 
+
+* Discord: [IOG's technical Discord](https://discord.gg/3dHCe6X88f)
+* E-mail: support@blockfrost.io
+* Twitter/X: [@Blockfrost_io](https://x.com/Blockfrost_io)
+
+## FAQ
+
+- Can I also contribute to these efforts?
+  - Definitely! All the deliverables are open-source and we welcome everyone who want to contribute to open an issue on our Github.
+- Didn't IOG already post their budget? Why you are not including there?
+  - IOE (Input Output Engineering) is a different entity than Blockfrost, therefore we are proposing our own budget.
+- Is there any dependency or overlap between this proposal and past Catalyst proposals?
+  - There is no dependency or overlap of this proposal with any other Blockfrost proposal. However, there are dependencies that we're using that has been funded by project Catalyst in the future. Pallas is a Rust library that I know have received funding before. We are also going to use Cardano Data nodes such as Dolos that I also know have received funding before too. We are building on shoulders of giants and none of this would be possible without these mature tools.
+- Following completion of this proposal, will there be any additional requests to Treasury or Catalyst submissions related to the maintenance of this proposal deliverables, or will this service be self-sustaining once work on this proposal is complete?
+  - At this moment, we do not know. As with all software in use, the Blockfrost Platform will also require resources for maintenance. That said, we're in the early stages and are exploring potential other sources of funding. As we are slowly handing over revenue to SPOs, we were thinking perhaps a DAO model, where a portion of the fees goes to the "Blockfrost treasury," could fund this in the future. Full disclosure, we have also discussed a potential token launch that might be used to secure this DAO. However, this is still early and needs discussion with the community too.
+- Can you show in some way that 1.3 million ada is a reasonable cost? For example, can you get recommendations from other community developers that this is roughly what it should be, or provide an estimate of the amount of work required?
+  - This is an excellent question, and I like the idea of gathering insights from other builderrs in the community. I'm not certain if this is the optimal approach, but we have posted a call for opinions on our Twitter, and I hope we will receive valuable feedback on this topic. The discussion is happening at [this thread](https://x.com/blockfrost_io/status/1913567785659023740).
+- Will anyone be able to run an Icebreaker, or does this needs approval from Blockfrost? Will there be a limit on the number of Icebreakers?
+  - At the moment, this is limited by a NFT license (that we provide for free, we just want to have contact information of which SPO is running which node, all one need is just to fill up a form to get one), given we're just in beta testing phase. When the beta testing is over, anyone will be able to join the clusters - not only SPOs but also full wallet users. Additionally, I think an important note is that anyone would be able to run their entire Blockfrost gateway cluster and "their own" Icebreakers. I envision that groups of SPOs might get together and start their own clusters with their own pricing, SLAs, endpoints etc and start to compete. We are also researching how we could have a decentralized P2P marketplace for Icebreakers to offer their services (imagine just setting the price per request on your Icebreaker, starting it and it will just connect to a cluster without you having to choose one) - but this is out of scope for this year as much more research needs to be done.
+- How will the revenue sharing model for Icebreakers be structured? Specifically, could you elaborate on how the share of Blockfrost revenue will be calculated and distributed to participating node operators?
+  - The pricing will be per request. When you look at our website, the price customer pays for 1M requests is around ~4 ADA. At the moment, we are rewarding Icebreakers with a minimum of 20 USD in ADA monthly, as the traffic to them is still small (under 20 USD), but as soon that traffic increases, they will be paid what they have served. In the future, when the full traffic is going to be handled fully in decentralized way, we will introduce a tax parameter, that will take a cut of all revenue and allocate it to the Blockfrost gateway to fund the infrastructure and administrative fees for running it. I imagine people will compete in a way that will start new Gateways with lower taxes to attract the Icebreakers. We are also investigating a possible DAO for this, but this is still in research and out of scope for this 2025 proposal.
+
+
+
+We have collected questions from the community and we are adding [it to the budget community Github PR](https://github.com/blockfrost/blockfrost-platform/pull/310).
+
+The rendered version of this proposal can be found at [this link](https://mmahut-2025budget.blockfrost-platform.pages.dev/budget).
+- **Audit & Oversight Allocation:** 65000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
+- **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
+
+## References
+- Constitution Hash: 8c653ee5c9800e6d31e79b5a7f7d4400c81d44717ad4db633dc18d4c07e4a4fd00
+- Approved Net Change Limit Hash: 9b62b3c632f329016a968ac25211825bb4f84b12461121c7da3aa11df92370f900
+- Approved Budget Hash: e14de8d9dc4f4ddf3fe9250a8a926e20f10e99b86bd0610b77d7a054981591ee00
+
+## Budget Reference
+> On behalf of Intersect and the Cardano Budget Committee, this Budget Info Action proposes a Cardano Blockchain Ecosystem Budget of 275,269,340 ada. The period during which this Budget Info Action remains in effect will begin at the close of its voting period and continue for 73 epochs (52 weeks). This budget is an aggregate allocation and following Treasury Withdrawal(s) must be in compliance with an approved and active Net Change Limit, among other conditions. This budget comprises 39 proposals that support maintenance, development, marketing, innovation, and governance initiatives within the Cardano Blockchain Ecosystem.
+
+## Net Change Limit Clause
+> The total requested funding sits below the Net Change Limit (NCL) currently in force, 350 trillion lovelace, or 350 million ada, as of 8 May 2025. Consequently, each subsequent Treasury Withdrawal must be presented and approved only if it remains within the then-active NCL, in line with Article IV of the Cardano Constitution and Guardrail: TREASURY-02a.
+
+## Constitutional Requirements
+
+### Article IV, Section 3
+> Withdrawals from the Cardano Blockchain treasury that would cause the Cardano Blockchain treasury balance to violate the then applicable net change limit shall not be permitted.
+> No withdrawals from the Cardano Blockchain treasury shall be permitted unless such withdrawals have been authorized and are being made pursuant to a budget for the Cardano Blockchain that is then in effect as required by the Cardano Blockchain Guardrails Appendix, and which has not been determined by the Constitutional Committee to be unconstitutional.
+
+### Article IV, Section 4
+> Any governance action requesting ada from the Cardano Blockchain treasury shall require an allocation of ada as a part of such funding request to cover the cost of periodic independent audits and the implementation of oversight metrics as to the use of such ada.
+> Contractual obligations governing the use of ada received from the Cardano Blockchain treasury pursuant to a Cardano Blockchain ecosystem budget shall include dispute resolution provisions.
+
+### Article IV, Section 5
+> Any ada received from a Cardano Blockchain treasury withdrawal, so long as such ada is being held directly or indirectly by an administrator prior to further disbursement, must be kept in one or more separate accounts that can be audited by the Cardano Community, and such accounts shall not be delegated to an SPO but must be delegated to the predefined auto abstain voting option.
+
+### Guardrails on Treasury Withdrawal Actions
+> TREASURY-01a (x) A net change limit for the Cardano treasury's balance per period of time **must** be agreed by the DReps via an on-chain governance action with a threshold of greater than 50% of the active voting stake.
+> TREASURY-02a (x) Withdrawals from the Cardano Blockchain treasury made pursuant to an approved Cardano Blockchain ecosystem budget **must not** exceed the net change limit for the Cardano Treasury's balance per period of time.
+> TREASURY-03a (x) Withdrawals from the Cardano Blockchain treasury **must** be denominated in ada.
+> TREASURY-04a (x) Withdrawals from the Cardano Blockchain treasury **must not** be ratified until there is a Cardano Community approved Cardano Blockchain ecosystem budget then in effect pursuant to a previous on-chain governance action agreed by the DReps with a threshold of greater than 50% of the active voting stake.
+
+## Fund Management & Oversight
+- Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
+- Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/69/treasury_withdrawal.md
+++ b/proposals/69/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Gerolamo - cardano node in typescript
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 578,571 ADA (578571000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** A node that can run in the browser.
+- **Audit & Oversight Allocation:** 28928 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/71/treasury_withdrawal.md
+++ b/proposals/71/treasury_withdrawal.md
@@ -5,16 +5,24 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Cexplorer.io – Developer-Focused Blockchain Explorer for Cardano
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 266,667 ADA (266667000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Cexplorer.io is a high-performance, feature-rich blockchain explorer designed specifically for the Cardano ecosystem. It offers deep on-chain insights, real-time data access, and powerful tools for developers, stake pool operators, and users. With over 50,000 monthly users and millions of processed data requests, Cexplorer.io has become a trusted resource in the Cardano community.
+
+This proposal seeks funding to ensure the long-term sustainability of the platform through infrastructure maintenance and continuous improvement. It includes two key areas:
+
+BAU/Maintenance – Covering costs for server infrastructure, backend/frontend development, and bug fixes to ensure stability, uptime, and security.
+
+Enhancements & New Features – Expanding the team with additional developers and a UI designer to deliver a better user experience, improved performance, and new developer-oriented features.
+
+Our mission is to provide a scalable, developer-friendly explorer that empowers the Cardano community with transparent, accessible, and actionable data. By supporting this proposal, Intersect and the broader community invest in critical infrastructure that enhances transparency, encourages innovation, and reduces friction for anyone building on or interacting with Cardano.
+- **Audit & Oversight Allocation:** 13333 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +58,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/719/treasury_withdrawal.md
+++ b/proposals/719/treasury_withdrawal.md
@@ -5,16 +5,18 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Beyond Minimum Viable Governance: Iteratively Improving on Cardano Voltaire
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 592,780 ADA (592780000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** * This initiative will establish a robust framework for evaluating and enhancing Cardano's governance system. We will identify and benchmark key governance metrics to assess the health, performance, and overall impact of our decentralized decision-making processes. The resulting 'State of Governance' report will provide a structured evaluation of participation, track vital Key Performance Indicators (KPIs), map the evolving governance ecosystem, and pinpoint specific areas for improvement.
+
+* To ensure our findings are grounded in real-world experience, we will engage the Cardano community through various channels. These include virtual workshops, targeted surveys, and in-depth user interviews. By actively gathering and synthesizing community insights, we will gain a comprehensive understanding of the current state of governance. This will allow us to formulate actionable recommendations and pave the way for post-MVG (Minimum Viable Governance) evolution. Where appropriate, these recommendations will be developed into initial drafts of Cardano Problem Statements (CPSs) or Cardano Improvement Proposals (CIPs), directly reflecting the community's vision for a more robust and effective governance future.
+- **Audit & Oversight Allocation:** 29639 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +52,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/729/treasury_withdrawal.md
+++ b/proposals/729/treasury_withdrawal.md
@@ -5,16 +5,20 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Cardano Builder DAO
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 12,000,000 ADA (12000000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** The Cardano Builder DAO (**CB DAO**) is a **smart contract-enforced**, **member-governed funding mechanism** created to **support the application-layer growth of the Cardano ecosystem**. Its core purpose is to **provide sustainable financial backing** and **strategic oversight to high-impact projects** that are directly responsible for existing user adoption, on-chain activity, Total Value Locked (TVL), and ecosystem engagement.
+ 
+While Cardano’s governance structure and funding mechanisms, such as Project Catalyst and core development committees, have been instrumental in bootstrapping protocol advancements and open-source tooling, **there remains a substantial gap in ongoing support for live, user-facing products/services. CB DAO fills that gap.**
+ 
+Through a **transparent governance framework**, **strict accountability mechanisms**, and a **metrics-first funding approach**, CB DAO ensures that builders with growing products on mainnet can scale sustainably, integrate cutting-edge Cardano infrastructure (e.g. Hydra, Leios, Midgard), and contribute to the ecosystem’s long-term growth.
+- **Audit & Oversight Allocation:** 600000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +54,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/737/treasury_withdrawal.md
+++ b/proposals/737/treasury_withdrawal.md
@@ -5,16 +5,30 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: A member-based organization for the Cardano ecosystem: Intersect
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 15,750,000 ADA (15750000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Since its inception, Intersect has played a critical role in Cardano's decentralized transition, including:
+
+- Stewarding the Chang and Plomin upgrades
+Facilitating Cardano’s first Constitution
+- Managing the 2025 roadmap and budget cycle
+Supporting SPOs, DRePs, and CC participants
+- Organizing global workshops, hubs, and governance events
+- Maintaining the Cardano core Haskell codebases through its Open Source Office
+
+Intersect will now not seek retrospective funding for our 2025 work to date. This request covers June 2025 to June 2026.
+
+Request: ₳15.75m allocation ($7.875M USD equivalent)
+- Amount is an allocation, funding is based on USD and to be disbursed quarterly based on exchange rate
+- $500K earmarked for elected committee member stipends
+- Any surplus will be swept back into the Treasury
+- **Audit & Oversight Allocation:** 787500 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +64,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/745/treasury_withdrawal.md
+++ b/proposals/745/treasury_withdrawal.md
@@ -5,16 +5,28 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Complete Web3 developer stack to make Cardano the smart contract layer for Bitcoin
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 600,000 ADA (600000000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Maestro proposes a comprehensive infrastructure solution that positions Cardano as Bitcoin’s primary smart contract and DeFi execution layer. Leveraging Maestro’s enterprise-grade UTXO infrastructure platform, this integration will bridge Bitcoin's substantial liquidity and large user base directly into the Cardano ecosystem.
+
+Maestro’s solution will provide a complete suite of developer-friendly infrastructure services and tools, including:
+Blockchain Indexer: For real-time blockchain data querying and insights.
+
+- Mempool Monitoring: Enabling developers to detect transactions and on-chain events instantly, even before they are confirmed.
+- Event Notification System: Allowing instant webhook alerts for on-chain activities, significantly enhancing the responsiveness of dApps.
+- Wallet Manager: Facilitating secure, efficient wallet management, address derivation, and user transaction tracking.
+
+These tools significantly improve the developer experience, dramatically reducing complexity and integration overhead. By abstracting away blockchain complexities, Maestro empowers developers to quickly build and deploy advanced DeFi applications, wallets, and Layer-2 integrations, directly utilizing Bitcoin liquidity.
+
+Maestro already supports numerous Cardano projects expanding into Bitcoin (e.g., Fluidtokens lending protocol, Tokeo Wallet, Begin Wallet, Lace Wallet) and Cardano L2s like Midgard, Sundial, zkFold, and BitcoinOS. Recent support for Midnight further expands these possibilities, enabling private DeFi transactions anchored by Bitcoin’s economic security.
+This integration will act as a catalyst for ecosystem growth, positioning Cardano firmly as Bitcoin’s natural DeFi and smart contract execution environment.
+- **Audit & Oversight Allocation:** 30000 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +62,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+

--- a/proposals/81/treasury_withdrawal.md
+++ b/proposals/81/treasury_withdrawal.md
@@ -5,16 +5,16 @@ This template combines the constitutional requirements for Treasury Withdrawals
 and the terms established in the approved Budget Info Action.  Replace each
 placeholder ({{...}}) with the appropriate value for each proposal.
 -->
-# Treasury Withdrawal Proposal: {{ProposalTitle}}
+# Treasury Withdrawal Proposal: Midgard - Optimistic Rollups
 
 ## Withdrawal Details
-- **Amount:** {{AdaAmount}} ADA ({{LovelaceAmount}} lovelace)
-- **Destination Address:** {{DestinationAddress}}
-- **Administrator:** {{AdministratorName}}
-- **Purpose / Description:** {{ProposalDescription}}
-- **Audit & Oversight Allocation:** {{AuditAllocation}} ADA
-- **Contractual Dispute Resolution:** {{DisputeResolutionProvision}}
-- **Budget Info Action Reference:** {{BudgetInfoActionCID}}
+- **Amount:** 2,162,096 ADA (2162096000000 lovelace)
+- **Destination Address:** Intersect multi-signature escrow address (TBD)
+- **Administrator:** Intersect
+- **Purpose / Description:** Midgard is a modular framework for deploying optimistic rollup Layer 2s on the Cardano blockchain, designed to enhance transaction throughput, reduce costs, and enable advanced decentralized applications.
+- **Audit & Oversight Allocation:** 108104 ADA
+- **Contractual Dispute Resolution:** Binding arbitration per contract
+- **Budget Info Action Reference:** ipfs://bafybeicwrop4q7xvnyjdd5drumbe56sqtm5lbe2ul3c262zt4hgguzdycm
 - **Net Change Limit Compliance:** Proposal amount is within the then-active NCL per Guardrail TREASURY-02a.
 
 ## References
@@ -50,3 +50,4 @@ placeholder ({{...}}) with the appropriate value for each proposal.
 ## Fund Management & Oversight
 - Funds will be held under a smart-contract framework with multi-signature oversight as per Article IV, Section 2 of the Constitution.
 - Withdrawn funds will be kept in a separate, auditable account and delegated to the predefined auto-abstain voting option.
+


### PR DESCRIPTION
## Summary
- add 39 treasury withdrawal proposals based on budget and NCL hashes
- reorder each proposal so withdrawal details come right after the title and include references before the budget explanation
- reorder template sections to match proposal structure

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68484ee3eeec832db79e1066950ecdca